### PR TITLE
fix: Qualify `Plugin` use in `register_plugin!` macro

### DIFF
--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -221,7 +221,7 @@ pub fn register_plugin<R, A, C, E>(
 macro_rules! register_plugin {
     ($name:ident, $plugin:expr) => {
         #[$crate::linkme::distributed_slice($crate::plugins::STATIC_PLUGINS)]
-        static $name: &'static dyn Plugin<
+        static $name: &'static dyn $crate::plugins::Plugin<
             Resource = Box<dyn $crate::semantics::resource::Resource>,
             Ability = Box<dyn $crate::semantics::ability::Ability>,
             Caveat = Box<dyn $crate::semantics::caveat::Caveat>,


### PR DESCRIPTION
**I didn't test this yet**. I literally edited this in the github interface :sweat_smile: (after locally noticing that the macro wouldn't work without an import).

Just noticed that there was another identifier that's probably better qualified in the macro.

:v: