### PR TITLE
feat: Implement Serialize/Deserialize for UCAN

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -59,19 +59,19 @@ where
     }
 
     /// Set the issuer of the UCAN
-    pub fn issued_by<S: AsRef<str>>(mut self, issuer: S) -> Self {
+    pub fn issued_by(mut self, issuer: impl AsRef<str>) -> Self {
         self.issuer = Some(issuer.as_ref().to_string());
         self
     }
 
     /// Set the audience of the UCAN
-    pub fn for_audience<S: AsRef<str>>(mut self, audience: S) -> Self {
+    pub fn for_audience(mut self, audience: impl AsRef<str>) -> Self {
         self.audience = Some(audience.as_ref().to_string());
         self
     }
 
     /// Set the nonce of the UCAN
-    pub fn with_nonce<S: AsRef<str>>(mut self, nonce: S) -> Self {
+    pub fn with_nonce(mut self, nonce: impl AsRef<str>) -> Self {
         self.nonce = Some(nonce.as_ref().to_string());
         self
     }

--- a/src/did_verifier.rs
+++ b/src/did_verifier.rs
@@ -56,7 +56,7 @@ impl DidVerifierMap {
         self.map
             .get(method)
             .ok_or_else(|| Error::VerifyingError {
-                msg: format!("Unrecognized DID method, {}", method).to_string(),
+                msg: format!("Unrecognized DID method, {}", method),
             })?
             .verify(identifier, payload, signature)
             .map_err(|e| Error::VerifyingError { msg: e.to_string() })


### PR DESCRIPTION
Also: Take `impl AsRef<str>` in some places instead of `String` (and standardize on specifying it as an `impl`-in-place).
Also also: Encode `EmptyCaveat` as `{}` instead of `null`