### PR TITLE
refactor: Adjustments to `Store`s & `Agent`s

### DIFF
--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -14,7 +14,7 @@ use std::{collections::BTreeMap, marker::PhantomData};
 use thiserror::Error;
 use web_time::SystemTime;
 
-/// A stateful agent capable of delegatint to others, and being delegated to.
+/// A stateful agent capable of delegating to others, and being delegated to.
 ///
 /// This is helpful for sessions where more than one delegation will be made.
 #[derive(Debug)]

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -29,7 +29,7 @@ pub struct Agent<
     pub did: &'a DID,
 
     /// The attached [`deleagtion::Store`][super::store::Store].
-    pub store: &'a mut S,
+    pub store: S,
 
     signer: &'a <DID as Did>::Signer,
     _marker: PhantomData<(V, Enc)>,
@@ -47,7 +47,7 @@ where
     Payload<DID>: TryFrom<Named<Ipld>>,
     Named<Ipld>: From<Payload<DID>>,
 {
-    pub fn new(did: &'a DID, signer: &'a <DID as Did>::Signer, store: &'a mut S) -> Self {
+    pub fn new(did: &'a DID, signer: &'a <DID as Did>::Signer, store: S) -> Self {
         Self {
             did,
             store,
@@ -120,7 +120,7 @@ where
     }
 
     pub fn receive(
-        &mut self,
+        &self,
         cid: Cid, // FIXME remove and generate from the capsule header?
         delegation: Delegation<DID, V, Enc>,
     ) -> Result<(), ReceiveError<S::DelegationStoreError, DID>> {

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -93,14 +93,12 @@ where
             }
         }
 
-        let to_delegate = &self
+        let proofs = &self
             .store
             .get_chain(&self.did, &subject, "/".into(), vec![], now)
             .map_err(DelegateError::StoreError)?
-            .ok_or(DelegateError::ProofsNotFound)?
-            .first()
-            .1
-            .payload();
+            .ok_or(DelegateError::ProofsNotFound)?;
+        let to_delegate = proofs.first().1.payload();
 
         let mut policy = to_delegate.policy.clone();
         policy.append(&mut new_policy.clone());

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -1,5 +1,6 @@
 use super::{payload::Payload, policy::Predicate, store::Store, Delegation};
 use crate::ability::arguments::Named;
+use crate::did;
 use crate::{
     crypto::{signature::Envelope, varsig, Nonce},
     did::Did,
@@ -19,10 +20,10 @@ use web_time::SystemTime;
 /// This is helpful for sessions where more than one delegation will be made.
 #[derive(Debug)]
 pub struct Agent<
-    DID: Did,
     S: Store<DID, V, Enc>,
-    V: varsig::Header<Enc>,
-    Enc: Codec + TryFrom<u64> + Into<u64>,
+    DID: Did = did::preset::Verifier,
+    V: varsig::Header<Enc> + Clone = varsig::header::Preset,
+    Enc: Codec + Into<u64> + TryFrom<u64> = varsig::encoding::Preset,
 > {
     /// The [`Did`][Did] of the agent.
     pub did: DID,
@@ -35,11 +36,11 @@ pub struct Agent<
 }
 
 impl<
-        DID: Did + Clone,
         S: Store<DID, V, Enc> + Clone,
+        DID: Did + Clone,
         V: varsig::Header<Enc> + Clone,
         Enc: Codec + TryFrom<u64> + Into<u64>,
-    > Agent<DID, S, V, Enc>
+    > Agent<S, DID, V, Enc>
 where
     Ipld: Encode<Enc>,
     Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -10,6 +10,7 @@ use libipld_core::codec::Encode;
 use libipld_core::ipld::Ipld;
 use libipld_core::{cid::Cid, codec::Codec};
 use nonempty::NonEmpty;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::Infallible,
@@ -72,36 +73,77 @@ use web_time::SystemTime;
 /// linkStyle 6 stroke:orange;
 /// linkStyle 1 stroke:orange;
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct MemoryStore<
     DID: did::Did + Ord = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
     C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
 > {
-    ucans: BTreeMap<Cid, Delegation<DID, V, C>>,
+    inner: Arc<RwLock<MemoryStoreInner<DID, V, C>>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct MemoryStoreInner<
+    DID: did::Did + Ord = did::preset::Verifier,
+    V: varsig::Header<C> = varsig::header::Preset,
+    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+> {
+    ucans: BTreeMap<Cid, Arc<Delegation<DID, V, C>>>,
     index: BTreeMap<Option<DID>, BTreeMap<DID, BTreeSet<Cid>>>,
     revocations: BTreeSet<Cid>,
 }
 
-impl MemoryStore {
+impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>>
+    MemoryStore<DID, V, C>
+{
     pub fn new() -> Self {
         Self::default()
     }
 
     pub fn len(&self) -> usize {
-        self.ucans.len()
+        self.read().ucans.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ucans.is_empty() // FIXME acocunt for revocations?
+        self.read().ucans.is_empty() // FIXME acocunt for revocations?
+    }
+
+    fn read(&self) -> RwLockReadGuard<'_, MemoryStoreInner<DID, V, C>> {
+        match self.inner.read() {
+            Ok(guard) => guard,
+            Err(poison) => {
+                // We ignore lock poisoning for simplicity
+                poison.into_inner()
+            }
+        }
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, MemoryStoreInner<DID, V, C>> {
+        match self.inner.write() {
+            Ok(guard) => guard,
+            Err(poison) => {
+                // We ignore lock poisoning for simplicity
+                poison.into_inner()
+            }
+        }
+    }
+}
+
+impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Default
+    for MemoryStore<DID, V, C>
+{
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
     }
 }
 
 impl<DID: Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Default
-    for MemoryStore<DID, V, C>
+    for MemoryStoreInner<DID, V, C>
 {
     fn default() -> Self {
-        MemoryStore {
+        MemoryStoreInner {
             ucans: BTreeMap::new(),
             index: BTreeMap::new(),
             revocations: BTreeSet::new(),
@@ -125,30 +167,34 @@ where
     fn get(
         &self,
         cid: &Cid,
-    ) -> Result<Option<&Delegation<DID, V, Enc>>, Self::DelegationStoreError> {
-        Ok(self.ucans.get(cid))
+    ) -> Result<Option<Arc<Delegation<DID, V, Enc>>>, Self::DelegationStoreError> {
+        // cheap Arc clone
+        Ok(self.read().ucans.get(cid).cloned())
         // FIXME
     }
 
     fn insert(
-        &mut self,
+        &self,
         cid: Cid,
         delegation: Delegation<DID, V, Enc>,
     ) -> Result<(), Self::DelegationStoreError> {
-        self.index
+        let mut write_tx = self.write();
+
+        write_tx
+            .index
             .entry(delegation.subject().clone())
             .or_default()
             .entry(delegation.audience().clone())
             .or_default()
             .insert(cid);
 
-        self.ucans.insert(cid.clone(), delegation);
+        write_tx.ucans.insert(cid.clone(), Arc::new(delegation));
 
         Ok(())
     }
 
-    fn revoke(&mut self, cid: Cid) -> Result<(), Self::DelegationStoreError> {
-        self.revocations.insert(cid);
+    fn revoke(&self, cid: Cid) -> Result<(), Self::DelegationStoreError> {
+        self.write().revocations.insert(cid);
         Ok(())
     }
 
@@ -159,12 +205,14 @@ where
         command: String,
         policy: Vec<Predicate>, // FIXME
         now: SystemTime,
-    ) -> Result<Option<NonEmpty<(Cid, &Delegation<DID, V, Enc>)>>, Self::DelegationStoreError> {
+    ) -> Result<Option<NonEmpty<(Cid, Arc<Delegation<DID, V, Enc>>)>>, Self::DelegationStoreError>
+    {
         let blank_set = BTreeSet::new();
         let blank_map = BTreeMap::new();
+        let read_tx = self.read();
 
-        let all_powerlines = self.index.get(&None).unwrap_or(&blank_map);
-        let all_aud_for_subject = self.index.get(subject).unwrap_or(&blank_map);
+        let all_powerlines = read_tx.index.get(&None).unwrap_or(&blank_map);
+        let all_aud_for_subject = read_tx.index.get(subject).unwrap_or(&blank_map);
         let powerline_candidates = all_powerlines.get(aud).unwrap_or(&blank_set);
         let sub_candidates = all_aud_for_subject.get(aud).unwrap_or(&blank_set);
 
@@ -189,11 +237,11 @@ where
                 }
 
                 'inner: for cid in parent_cid_candidates {
-                    if self.revocations.contains(cid) {
+                    if read_tx.revocations.contains(cid) {
                         continue;
                     }
 
-                    if let Some(delegation) = self.ucans.get(cid) {
+                    if let Some(delegation) = read_tx.ucans.get(cid) {
                         if delegation.check_time(now).is_err() {
                             continue;
                         }
@@ -221,7 +269,7 @@ where
                             }
                         }
 
-                        hypothesis_chain.push((cid.clone(), delegation));
+                        hypothesis_chain.push((cid.clone(), Arc::clone(delegation)));
 
                         let issuer = delegation.issuer().clone();
 

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -10,7 +10,10 @@ use libipld_core::codec::Encode;
 use libipld_core::ipld::Ipld;
 use libipld_core::{cid::Cid, codec::Codec};
 use nonempty::NonEmpty;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::Infallible,
+};
 use web_time::SystemTime;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -117,12 +120,13 @@ where
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,
     Delegation<DID, V, Enc>: Encode<Enc>,
 {
-    type DelegationStoreError = String; // FIXME misisng
+    type DelegationStoreError = Infallible;
 
-    fn get(&self, cid: &Cid) -> Result<&Delegation<DID, V, Enc>, Self::DelegationStoreError> {
-        self.ucans
-            .get(cid)
-            .ok_or(format!("not found in delegation memstore: {:?}", cid).into())
+    fn get(
+        &self,
+        cid: &Cid,
+    ) -> Result<Option<&Delegation<DID, V, Enc>>, Self::DelegationStoreError> {
+        Ok(self.ucans.get(cid))
         // FIXME
     }
 

--- a/src/delegation/store/traits.rs
+++ b/src/delegation/store/traits.rs
@@ -11,7 +11,10 @@ use web_time::SystemTime;
 pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + Into<u64>> {
     type DelegationStoreError: Debug;
 
-    fn get(&self, cid: &Cid) -> Result<&Delegation<DID, V, Enc>, Self::DelegationStoreError>;
+    fn get(
+        &self,
+        cid: &Cid,
+    ) -> Result<Option<&Delegation<DID, V, Enc>>, Self::DelegationStoreError>;
 
     fn insert(
         &mut self,
@@ -60,7 +63,7 @@ pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + In
     fn get_many(
         &self,
         cids: &[Cid],
-    ) -> Result<Vec<&Delegation<DID, V, Enc>>, Self::DelegationStoreError> {
+    ) -> Result<Vec<Option<&Delegation<DID, V, Enc>>>, Self::DelegationStoreError> {
         cids.iter().try_fold(vec![], |mut acc, cid| {
             acc.push(self.get(cid)?);
             Ok(acc)
@@ -73,7 +76,7 @@ impl<T: Store<DID, V, C>, DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64
 {
     type DelegationStoreError = <T as Store<DID, V, C>>::DelegationStoreError;
 
-    fn get(&self, cid: &Cid) -> Result<&Delegation<DID, V, C>, Self::DelegationStoreError> {
+    fn get(&self, cid: &Cid) -> Result<Option<&Delegation<DID, V, C>>, Self::DelegationStoreError> {
         (**self).get(cid)
     }
 

--- a/src/delegation/store/traits.rs
+++ b/src/delegation/store/traits.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use libipld_core::{cid::Cid, codec::Codec};
 use nonempty::NonEmpty;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use web_time::SystemTime;
 
 pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + Into<u64>> {
@@ -14,10 +14,10 @@ pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + In
     fn get(
         &self,
         cid: &Cid,
-    ) -> Result<Option<&Delegation<DID, V, Enc>>, Self::DelegationStoreError>;
+    ) -> Result<Option<Arc<Delegation<DID, V, Enc>>>, Self::DelegationStoreError>;
 
     fn insert(
-        &mut self,
+        &self,
         cid: Cid,
         delegation: Delegation<DID, V, Enc>,
     ) -> Result<(), Self::DelegationStoreError>;
@@ -25,7 +25,7 @@ pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + In
     // FIXME validate invocation
     // store invocation
     // just... move to invocation
-    fn revoke(&mut self, cid: Cid) -> Result<(), Self::DelegationStoreError>;
+    fn revoke(&self, cid: Cid) -> Result<(), Self::DelegationStoreError>;
 
     fn get_chain(
         &self,
@@ -34,7 +34,7 @@ pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + In
         command: String,
         policy: Vec<Predicate>,
         now: SystemTime,
-    ) -> Result<Option<NonEmpty<(Cid, &Delegation<DID, V, Enc>)>>, Self::DelegationStoreError>;
+    ) -> Result<Option<NonEmpty<(Cid, Arc<Delegation<DID, V, Enc>>)>>, Self::DelegationStoreError>;
 
     fn get_chain_cids(
         &self,
@@ -63,32 +63,34 @@ pub trait Store<DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + In
     fn get_many(
         &self,
         cids: &[Cid],
-    ) -> Result<Vec<Option<&Delegation<DID, V, Enc>>>, Self::DelegationStoreError> {
-        cids.iter().try_fold(vec![], |mut acc, cid| {
-            acc.push(self.get(cid)?);
-            Ok(acc)
-        })
+    ) -> Result<Vec<Option<Arc<Delegation<DID, V, Enc>>>>, Self::DelegationStoreError> {
+        cids.iter()
+            .map(|cid| self.get(cid))
+            .collect::<Result<_, Self::DelegationStoreError>>()
     }
 }
 
 impl<T: Store<DID, V, C>, DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>>
-    Store<DID, V, C> for &mut T
+    Store<DID, V, C> for &T
 {
     type DelegationStoreError = <T as Store<DID, V, C>>::DelegationStoreError;
 
-    fn get(&self, cid: &Cid) -> Result<Option<&Delegation<DID, V, C>>, Self::DelegationStoreError> {
+    fn get(
+        &self,
+        cid: &Cid,
+    ) -> Result<Option<Arc<Delegation<DID, V, C>>>, Self::DelegationStoreError> {
         (**self).get(cid)
     }
 
     fn insert(
-        &mut self,
+        &self,
         cid: Cid,
         delegation: Delegation<DID, V, C>,
     ) -> Result<(), Self::DelegationStoreError> {
         (**self).insert(cid, delegation)
     }
 
-    fn revoke(&mut self, cid: Cid) -> Result<(), Self::DelegationStoreError> {
+    fn revoke(&self, cid: Cid) -> Result<(), Self::DelegationStoreError> {
         (**self).revoke(cid)
     }
 
@@ -99,7 +101,8 @@ impl<T: Store<DID, V, C>, DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64
         command: String,
         policy: Vec<Predicate>,
         now: SystemTime,
-    ) -> Result<Option<NonEmpty<(Cid, &Delegation<DID, V, C>)>>, Self::DelegationStoreError> {
+    ) -> Result<Option<NonEmpty<(Cid, Arc<Delegation<DID, V, C>>)>>, Self::DelegationStoreError>
+    {
         (**self).get_chain(audience, subject, command, policy, now)
     }
 }

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -86,7 +86,7 @@ where
     }
 
     pub fn invoke(
-        &mut self,
+        &self,
         audience: Option<DID>,
         subject: DID,
         ability: T,
@@ -172,7 +172,7 @@ where
     // }
 
     pub fn receive(
-        &mut self,
+        &self,
         invocation: Invocation<T, DID, V, C>,
     ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::DelegationStoreError, S, V, C>>
     where
@@ -184,7 +184,7 @@ where
     }
 
     pub fn generic_receive(
-        &mut self,
+        &self,
         invocation: Invocation<T, DID, V, C>,
         now: SystemTime,
     ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::DelegationStoreError, S, V, C>>
@@ -233,7 +233,7 @@ where
     }
 
     // pub fn revoke(
-    //     &mut self,
+    //     &self,
     //     subject: DID,
     //     cause: Option<Cid>,
     //     cid: Cid,

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -635,7 +635,7 @@ mod tests {
             );
 
             let inv_store = crate::invocation::store::MemoryStore::default();
-            let mut del_store = crate::delegation::store::MemoryStore::default();
+            let del_store = crate::delegation::store::MemoryStore::default();
 
             // Scenario
             // ========
@@ -750,17 +750,17 @@ mod tests {
 
         #[test_log::test]
         fn test_chain_ok() -> TestResult {
-            let mut ctx = setup_test_chain()?;
+            let ctx = setup_test_chain()?;
 
             let mut agent: Agent<
                 '_,
-                &mut crate::invocation::store::MemoryStore<AccountManage>,
+                &crate::invocation::store::MemoryStore<AccountManage>,
                 &crate::delegation::store::MemoryStore,
                 AccountManage,
             > = Agent::new(
                 &ctx.server,
                 &ctx.server_signer,
-                &mut ctx.inv_store,
+                &ctx.inv_store,
                 &ctx.del_store,
             );
 
@@ -771,17 +771,17 @@ mod tests {
 
         #[test_log::test]
         fn test_chain_wrong_sub() -> TestResult {
-            let mut ctx = setup_test_chain()?;
+            let ctx = setup_test_chain()?;
 
             let mut agent: Agent<
                 '_,
-                &mut crate::invocation::store::MemoryStore<AccountManage>,
+                &crate::invocation::store::MemoryStore<AccountManage>,
                 &crate::delegation::store::MemoryStore,
                 AccountManage,
             > = Agent::new(
                 &ctx.server,
                 &ctx.server_signer,
-                &mut ctx.inv_store,
+                &ctx.inv_store,
                 &ctx.del_store,
             );
 


### PR DESCRIPTION
Ongoing discussion: https://talk.fission.codes/t/rs-ucan-1-0-api-notes/5347/5

- Made `delegation::Store::get` return `Option`
- Make `delegation::Store::get` return `Arc`s
- Make `delegation::Store::insert` take `&self` instead of `&mut self`
- Similar changes for `invocation::Store`