### PR TITLE
refactor: Make `Agent` take `DID` by value

### DIFF
--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -1,5 +1,6 @@
 use super::{payload::Payload, policy::Predicate, store::Store, Delegation};
 use crate::ability::arguments::Named;
+use crate::did;
 use crate::{
     crypto::{signature::Envelope, varsig, Nonce},
     did::Did,
@@ -19,10 +20,10 @@ use web_time::SystemTime;
 /// This is helpful for sessions where more than one delegation will be made.
 #[derive(Debug)]
 pub struct Agent<
-    DID: Did,
     S: Store<DID, V, Enc>,
-    V: varsig::Header<Enc>,
-    Enc: Codec + TryFrom<u64> + Into<u64>,
+    DID: Did = did::preset::Verifier,
+    V: varsig::Header<Enc> + Clone = varsig::header::Preset,
+    Enc: Codec + Into<u64> + TryFrom<u64> = varsig::encoding::Preset,
 > {
     /// The [`Did`][Did] of the agent.
     pub did: DID,
@@ -35,11 +36,11 @@ pub struct Agent<
 }
 
 impl<
-        DID: Did + Clone,
         S: Store<DID, V, Enc> + Clone,
+        DID: Did + Clone,
         V: varsig::Header<Enc> + Clone,
         Enc: Codec + TryFrom<u64> + Into<u64>,
-    > Agent<DID, S, V, Enc>
+    > Agent<S, DID, V, Enc>
 where
     Ipld: Encode<Enc>,
     Payload<DID>: TryFrom<Named<Ipld>>,


### PR DESCRIPTION
I think this makes sense, because in practice, if `Agent` is meant to be alive for a long time in a program, it's much easier to do that when it doesn't borrow data, but instead is self-contained. E.g. this way you can put it into an axum's `AppState`, or hold it across an await point in a tokio task.
The downside is that you're sometimes required to clone the `DID` and `Signer` that you put into the `Agent`, but I'd argue that, the longer the `Agent` lives for, the less often you're required to `clone` something into it.