### PR TITLE
refactor: Remove unused constraints

### DIFF
--- a/src/ability/pipe.rs
+++ b/src/ability/pipe.rs
@@ -1,22 +1,22 @@
 use crate::{crypto::varsig, delegation, did::Did, ipld};
 use libipld_core::{codec::Codec, ipld::Ipld};
 
-pub struct Pipe<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> {
+pub struct Pipe<DID: Did, V: varsig::Header<C>, C: Codec> {
     pub source: Cap<DID, V, C>,
     pub sink: Cap<DID, V, C>,
 }
 
-pub enum Cap<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> {
+pub enum Cap<DID: Did, V: varsig::Header<C>, C: Codec> {
     Proof(delegation::Proof<DID, V, C>),
     Literal(Ipld),
 }
 
-pub struct PromisedPipe<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> {
+pub struct PromisedPipe<DID: Did, V: varsig::Header<C>, C: Codec> {
     pub source: PromisedCap<DID, V, C>,
     pub sink: PromisedCap<DID, V, C>,
 }
 
-pub enum PromisedCap<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> {
+pub enum PromisedCap<DID: Did, V: varsig::Header<C>, C: Codec> {
     Proof(delegation::Proof<DID, V, C>),
     Promised(ipld::Promised),
 }

--- a/src/ability/ucan/batch.rs
+++ b/src/ability/ucan/batch.rs
@@ -3,11 +3,11 @@
 // use std::collections::BTreeMap;
 //
 // #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-// pub struct Batch<A, DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + Into<u64>> {
+// pub struct Batch<A, DID: Did, V: varsig::Header<Enc>, Enc: Codec> {
 //     pub batch: Vec<Step<A, DID, V, Enc>>, // FIXME not quite right; would be nice to include meta etc
 // }
 //
-// pub struct Step<A, DID: Did, V: varsig::Header<Enc>, Enc: Codec + TryFrom<u64> + Into<u64>> {
+// pub struct Step<A, DID: Did, V: varsig::Header<Enc>, Enc: Codec> {
 //     pub subject: DID,
 //     pub audience: Option<DID>,
 //     pub ability: A, // FIXME promise version instead? Promised version shoudl be able to promise any field

--- a/src/crypto/signature/envelope.rs
+++ b/src/crypto/signature/envelope.rs
@@ -16,7 +16,7 @@ pub trait Envelope: Sized {
     type DID: Did;
     type Payload: Clone + Capsule + TryFrom<Named<Ipld>> + Into<Named<Ipld>>;
     type VarsigHeader: varsig::Header<Self::Encoder> + Clone;
-    type Encoder: Codec + TryFrom<u64> + Into<u64>;
+    type Encoder: Codec;
 
     fn varsig_header(&self) -> &Self::VarsigHeader;
     fn signature(&self) -> &<Self::DID as Did>::Signature;

--- a/src/crypto/varsig/header/eddsa.rs
+++ b/src/crypto/varsig/header/eddsa.rs
@@ -33,7 +33,7 @@ impl<C: Into<u64> + Clone> From<EdDsaHeader<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for EdDsaHeader<C> {
+impl<C: Codec> Header<C> for EdDsaHeader<C> {
     type Signature = ed25519_dalek::Signature;
     type Verifier = ed25519_dalek::VerifyingKey;
 

--- a/src/crypto/varsig/header/es256.rs
+++ b/src/crypto/varsig/header/es256.rs
@@ -38,7 +38,7 @@ impl<C: Into<u64>> From<Es256Header<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for Es256Header<C> {
+impl<C: Codec> Header<C> for Es256Header<C> {
     type Signature = p256::ecdsa::Signature;
     type Verifier = p256::ecdsa::VerifyingKey;
 

--- a/src/crypto/varsig/header/es256k.rs
+++ b/src/crypto/varsig/header/es256k.rs
@@ -38,7 +38,7 @@ impl<C: Into<u64>> From<Es256kHeader<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for Es256kHeader<C> {
+impl<C: Codec> Header<C> for Es256kHeader<C> {
     type Signature = k256::ecdsa::Signature;
     type Verifier = k256::ecdsa::VerifyingKey;
 

--- a/src/crypto/varsig/header/es512.rs
+++ b/src/crypto/varsig/header/es512.rs
@@ -38,7 +38,7 @@ impl<C: Into<u64>> From<Es512Header<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for Es512Header<C> {
+impl<C: Codec> Header<C> for Es512Header<C> {
     type Signature = p521::ecdsa::Signature;
     type Verifier = p521::ecdsa::VerifyingKey;
 

--- a/src/crypto/varsig/header/rs256.rs
+++ b/src/crypto/varsig/header/rs256.rs
@@ -51,7 +51,7 @@ impl<C: Into<u64>> From<Rs256Header<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for Rs256Header<C> {
+impl<C: Codec> Header<C> for Rs256Header<C> {
     type Signature = Signature;
     type Verifier = VerifyingKey;
 

--- a/src/crypto/varsig/header/rs512.rs
+++ b/src/crypto/varsig/header/rs512.rs
@@ -39,7 +39,7 @@ impl<C: Into<u64>> From<Rs512Header<C>> for Vec<u8> {
     }
 }
 
-impl<C: Codec + Into<u64> + TryFrom<u64>> Header<C> for Rs512Header<C> {
+impl<C: Codec> Header<C> for Rs512Header<C> {
     type Signature = Signature;
     type Verifier = VerifyingKey;
 

--- a/src/crypto/varsig/header/traits.rs
+++ b/src/crypto/varsig/header/traits.rs
@@ -2,9 +2,7 @@ use libipld_core::codec::{Codec, Encode};
 use signature::Verifier;
 use thiserror::Error;
 
-pub trait Header<Enc: Codec + TryFrom<u64> + Into<u64>>:
-    for<'a> TryFrom<&'a [u8]> + Into<Vec<u8>>
-{
+pub trait Header<Enc: Codec>: for<'a> TryFrom<&'a [u8]> + Into<Vec<u8>> {
     type Signature: signature::SignatureEncoding;
     type Verifier: signature::Verifier<Self::Signature>;
 

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -65,7 +65,7 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Capsul
     const TAG: &'static str = "ucan/prf";
 }
 
-impl<DID: Did, V: varsig::Header<C>, C: Codec + Into<u64> + TryFrom<u64>> Delegation<DID, V, C> {
+impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     pub fn new(
         varsig_header: V,
         signature: DID::Signature,

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -42,7 +42,7 @@ use web_time::SystemTime;
 pub struct Delegation<
     DID: Did = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     pub varsig_header: V,
     pub payload: Payload<DID>,
@@ -54,14 +54,12 @@ pub struct Delegation<
 pub struct Proof<
     DID: Did = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     pub prf: Vec<Link<Delegation<DID, V, C>>>,
 }
 
-impl<DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Capsule
-    for Proof<DID, V, C>
-{
+impl<DID: Did, V: varsig::Header<C>, C: Codec> Capsule for Proof<DID, V, C> {
     const TAG: &'static str = "ucan/prf";
 }
 
@@ -124,8 +122,7 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 }
 
-impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec + TryFrom<u64> + Into<u64>> Envelope
-    for Delegation<DID, V, C>
+impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Envelope for Delegation<DID, V, C>
 where
     Payload<DID>: TryFrom<Named<Ipld>>,
     Named<Ipld>: From<Payload<DID>>,
@@ -165,8 +162,7 @@ where
     }
 }
 
-impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec + TryFrom<u64> + Into<u64>> Serialize
-    for Delegation<DID, V, C>
+impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Serialize for Delegation<DID, V, C>
 where
     Payload<DID>: TryFrom<Named<Ipld>>,
 {
@@ -178,8 +174,8 @@ where
     }
 }
 
-impl<'de, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec + TryFrom<u64> + Into<u64>>
-    Deserialize<'de> for Delegation<DID, V, C>
+impl<'de, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Deserialize<'de>
+    for Delegation<DID, V, C>
 where
     Payload<DID>: TryFrom<Named<Ipld>>,
     <Payload<DID> as TryFrom<Named<Ipld>>>::Error: std::fmt::Display,

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -39,12 +39,8 @@ pub struct Agent<
     _marker: PhantomData<(V, C)>,
 }
 
-impl<
-        S: Store<DID, V, C> + Clone,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Agent<S, DID, V, C>
+impl<S: Store<DID, V, C> + Clone, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec>
+    Agent<S, DID, V, C>
 where
     Ipld: Encode<C>,
     Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -23,7 +23,7 @@ pub struct Agent<
     S: Store<DID, V, C>,
     DID: Did + Clone = did::preset::Verifier,
     V: varsig::Header<C> + Clone = varsig::header::Preset,
-    C: Codec + Into<u64> + TryFrom<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > where
     Ipld: Encode<C>,
     Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -78,7 +78,7 @@ use web_time::SystemTime;
 pub struct MemoryStore<
     DID: did::Did + Ord = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     inner: Arc<Mutex<MemoryStoreInner<DID, V, C>>>,
 }
@@ -87,16 +87,14 @@ pub struct MemoryStore<
 struct MemoryStoreInner<
     DID: did::Did + Ord = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     ucans: BTreeMap<Cid, Arc<Delegation<DID, V, C>>>,
     index: BTreeMap<Option<DID>, BTreeMap<DID, BTreeSet<Cid>>>,
     revocations: BTreeSet<Cid>,
 }
 
-impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>>
-    MemoryStore<DID, V, C>
-{
+impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec> MemoryStore<DID, V, C> {
     pub fn new() -> Self {
         Self::default()
     }
@@ -120,9 +118,7 @@ impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u
     }
 }
 
-impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Default
-    for MemoryStore<DID, V, C>
-{
+impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec> Default for MemoryStore<DID, V, C> {
     fn default() -> Self {
         Self {
             inner: Default::default(),
@@ -130,9 +126,7 @@ impl<DID: did::Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u
     }
 }
 
-impl<DID: Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> Default
-    for MemoryStoreInner<DID, V, C>
-{
+impl<DID: Did + Ord, V: varsig::Header<C>, C: Codec> Default for MemoryStoreInner<DID, V, C> {
     fn default() -> Self {
         MemoryStoreInner {
             ucans: BTreeMap::new(),
@@ -143,11 +137,8 @@ impl<DID: Did + Ord, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> 
 }
 
 // FIXME check that UCAN is valid
-impl<
-        DID: Did + Ord + Clone,
-        V: varsig::Header<Enc> + Clone,
-        Enc: Codec + TryFrom<u64> + Into<u64>,
-    > Store<DID, V, Enc> for MemoryStore<DID, V, Enc>
+impl<DID: Did + Ord + Clone, V: varsig::Header<Enc> + Clone, Enc: Codec> Store<DID, V, Enc>
+    for MemoryStore<DID, V, Enc>
 where
     Named<Ipld>: From<delegation::Payload<DID>>,
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/delegation/store/traits.rs
+++ b/src/delegation/store/traits.rs
@@ -14,7 +14,7 @@ use std::{fmt::Debug, sync::Arc};
 use thiserror::Error;
 use web_time::SystemTime;
 
-pub trait Store<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec + TryFrom<u64> + Into<u64>>
+pub trait Store<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec>
 where
     Ipld: Encode<C>,
     Payload<DID>: TryFrom<Named<Ipld>>,
@@ -89,12 +89,8 @@ where
     }
 }
 
-impl<
-        T: Store<DID, V, C>,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Store<DID, V, C> for &T
+impl<T: Store<DID, V, C>, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Store<DID, V, C>
+    for &T
 where
     Ipld: Encode<C>,
     Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/invocation.rs
+++ b/src/invocation.rs
@@ -54,7 +54,7 @@ pub struct Invocation<
     A,
     DID: did::Did = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     pub varsig_header: V,
     pub payload: Payload<A, DID>,
@@ -66,7 +66,7 @@ impl<
         A: Clone + ToCommand + ParseAbility,
         DID: Clone + did::Did,
         V: Clone + varsig::Header<C>,
-        C: Codec + TryFrom<u64> + Into<u64>,
+        C: Codec,
     > Encode<C> for Invocation<A, DID, V, C>
 where
     Ipld: Encode<C>,
@@ -79,12 +79,8 @@ where
     }
 }
 
-impl<
-        A: Clone + ToCommand + ParseAbility,
-        DID: Did + Clone,
-        V: varsig::Header<C>,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Invocation<A, DID, V, C>
+impl<A: Clone + ToCommand + ParseAbility, DID: Did + Clone, V: varsig::Header<C>, C: Codec>
+    Invocation<A, DID, V, C>
 where
     Ipld: Encode<C>,
 {
@@ -150,7 +146,7 @@ where
     }
 }
 
-impl<A, DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>> did::Verifiable<DID>
+impl<A, DID: Did, V: varsig::Header<C>, C: Codec> did::Verifiable<DID>
     for Invocation<A, DID, V, C>
 {
     fn verifier(&self) -> &DID {
@@ -162,7 +158,7 @@ impl<
         A: Clone + ToCommand + ParseAbility,
         DID: Did + Clone,
         V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
+        C: Codec,
     > From<Invocation<A, DID, V, C>> for Ipld
 where
     Named<Ipld>: From<A>,
@@ -177,7 +173,7 @@ impl<
         A: Clone + ToCommand + ParseAbility,
         DID: Did + Clone,
         V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
+        C: Codec,
     > Envelope for Invocation<A, DID, V, C>
 where
     Named<Ipld>: From<A>,
@@ -222,7 +218,7 @@ impl<
         A: Clone + ToCommand + ParseAbility,
         DID: Did + Clone,
         V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
+        C: Codec,
     > Serialize for Invocation<A, DID, V, C>
 where
     Named<Ipld>: From<A>,
@@ -241,7 +237,7 @@ impl<
         A: Clone + ToCommand + ParseAbility,
         DID: Did + Clone,
         V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
+        C: Codec,
     > Deserialize<'de> for Invocation<A, DID, V, C>
 where
     Named<Ipld>: From<A>,

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -68,8 +68,6 @@ where
     D: delegation::store::Store<DID, V, C>,
     V: varsig::Header<C> + Clone,
     C: Codec,
-    <S as Store<T, DID, V, C>>::InvocationStoreError: fmt::Debug,
-    <D as delegation::store::Store<DID, V, C>>::DelegationStoreError: fmt::Debug,
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,
     Named<Ipld>: From<delegation::Payload<DID>>,
 {
@@ -291,10 +289,7 @@ pub enum Recipient<T> {
 }
 
 #[derive(Debug, Error, EnumAsInner)]
-pub enum ReceiveError<T, DID: Did, D, S: Store<T, DID, V, C>, V: varsig::Header<C>, C: Codec>
-where
-    <S as Store<T, DID, V, C>>::InvocationStoreError: fmt::Debug,
-{
+pub enum ReceiveError<T, DID: Did, D, S: Store<T, DID, V, C>, V: varsig::Header<C>, C: Codec> {
     #[error("couldn't find delegation: {0}")]
     DelegationNotFound(Cid),
 

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -291,14 +291,8 @@ pub enum Recipient<T> {
 }
 
 #[derive(Debug, Error, EnumAsInner)]
-pub enum ReceiveError<
-    T,
-    DID: Did,
-    D,
-    S: Store<T, DID, V, C>,
-    V: varsig::Header<C>,
-    C: Codec + TryFrom<u64> + Into<u64>,
-> where
+pub enum ReceiveError<T, DID: Did, D, S: Store<T, DID, V, C>, V: varsig::Header<C>, C: Codec>
+where
     <S as Store<T, DID, V, C>>::InvocationStoreError: fmt::Debug,
 {
     #[error("couldn't find delegation: {0}")]

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -37,7 +37,7 @@ pub struct Agent<
     T: ToCommand = ability::preset::Preset,
     DID: Did + Clone = did::preset::Verifier,
     V: varsig::Header<C> + Clone = varsig::header::Preset,
-    C: Codec + Into<u64> + TryFrom<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > where
     Ipld: Encode<C>,
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,
@@ -67,7 +67,7 @@ where
     S: Store<T, DID, V, C>,
     D: delegation::store::Store<DID, V, C>,
     V: varsig::Header<C> + Clone,
-    C: Codec + Into<u64> + TryFrom<u64>,
+    C: Codec,
     <S as Store<T, DID, V, C>>::InvocationStoreError: fmt::Debug,
     <D as delegation::store::Store<DID, V, C>>::DelegationStoreError: fmt::Debug,
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,

--- a/src/invocation/payload.rs
+++ b/src/invocation/payload.rs
@@ -366,9 +366,7 @@ where
     }
 }
 
-impl<'de, A: ParseAbility + Deserialize<'de>, DID: Did + Deserialize<'de>> Deserialize<'de>
-    for Payload<A, DID>
-{
+impl<'de, A: ParseAbility, DID: Did + Deserialize<'de>> Deserialize<'de> for Payload<A, DID> {
     fn deserialize<D>(deserializer: D) -> Result<Payload<A, DID>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -379,7 +377,7 @@ impl<'de, A: ParseAbility + Deserialize<'de>, DID: Did + Deserialize<'de>> Deser
             "iss", "sub", "aud", "cmd", "args", "prf", "nonce", "cause", "meta", "iat", "exp",
         ];
 
-        impl<'de, T: ParseAbility + Deserialize<'de>, DID: Did + Deserialize<'de>> Visitor<'de>
+        impl<'de, T: ParseAbility, DID: Did + Deserialize<'de>> Visitor<'de>
             for InvocationPayloadVisitor<T, DID>
         {
             type Value = Payload<T, DID>;
@@ -480,7 +478,7 @@ impl<'de, A: ParseAbility + Deserialize<'de>, DID: Did + Deserialize<'de>> Deser
 
                 let ability = <T as ParseAbility>::try_parse(cmd.as_str(), args).map_err(|e| {
                     de::Error::custom(format!(
-                        "Unable to parse ability field for {:?} becuase {:?}",
+                        "Unable to parse ability field for {:?} because {:?}",
                         cmd, e
                     ))
                 })?;

--- a/src/invocation/store/memory.rs
+++ b/src/invocation/store/memory.rs
@@ -24,9 +24,7 @@ pub struct MemoryStoreInner<
     store: BTreeMap<Cid, Arc<Invocation<T, DID, V, C>>>,
 }
 
-impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>>
-    MemoryStore<T, DID, V, Enc>
-{
+impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec> MemoryStore<T, DID, V, Enc> {
     fn lock(&self) -> MutexGuard<'_, MemoryStoreInner<T, DID, V, Enc>> {
         match self.inner.lock() {
             Ok(guard) => guard,
@@ -38,9 +36,7 @@ impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>>
     }
 }
 
-impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>> Default
-    for MemoryStore<T, DID, V, Enc>
-{
+impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec> Default for MemoryStore<T, DID, V, Enc> {
     fn default() -> Self {
         Self {
             inner: Arc::new(Mutex::new(MemoryStoreInner {
@@ -50,8 +46,8 @@ impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>>
     }
 }
 
-impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>>
-    Store<T, DID, V, Enc> for MemoryStore<T, DID, V, Enc>
+impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec> Store<T, DID, V, Enc>
+    for MemoryStore<T, DID, V, Enc>
 {
     type InvocationStoreError = Infallible;
 

--- a/src/invocation/store/memory.rs
+++ b/src/invocation/store/memory.rs
@@ -9,7 +9,7 @@ pub struct MemoryStore<
     T = crate::ability::preset::Preset,
     DID: crate::did::Did = crate::did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     inner: Arc<Mutex<MemoryStoreInner<T, DID, V, C>>>,
 }
@@ -19,7 +19,7 @@ pub struct MemoryStoreInner<
     T = crate::ability::preset::Preset,
     DID: crate::did::Did = crate::did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + TryFrom<u64> + Into<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     store: BTreeMap<Cid, Arc<Invocation<T, DID, V, C>>>,
 }

--- a/src/invocation/store/traits.rs
+++ b/src/invocation/store/traits.rs
@@ -2,7 +2,7 @@ use crate::{crypto::varsig, did::Did, invocation::Invocation};
 use libipld_core::{cid::Cid, codec::Codec};
 use std::sync::Arc;
 
-pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec + Into<u64> + TryFrom<u64>> {
+pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec> {
     type InvocationStoreError;
 
     fn get(
@@ -21,13 +21,8 @@ pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec + Into<u64> + TryFro
     }
 }
 
-impl<
-        S: Store<T, DID, V, C>,
-        T,
-        DID: Did,
-        V: varsig::Header<C>,
-        C: Codec + Into<u64> + TryFrom<u64>,
-    > Store<T, DID, V, C> for &S
+impl<S: Store<T, DID, V, C>, T, DID: Did, V: varsig::Header<C>, C: Codec> Store<T, DID, V, C>
+    for &S
 {
     type InvocationStoreError = <S as Store<T, DID, V, C>>::InvocationStoreError;
 

--- a/src/invocation/store/traits.rs
+++ b/src/invocation/store/traits.rs
@@ -1,9 +1,9 @@
 use crate::{crypto::varsig, did::Did, invocation::Invocation};
 use libipld_core::{cid::Cid, codec::Codec};
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec> {
-    type InvocationStoreError;
+    type InvocationStoreError: Debug;
 
     fn get(
         &self,

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -37,20 +37,16 @@ pub struct Receipt<
     _marker: std::marker::PhantomData<C>,
 }
 
-impl<T: Responds, DID: Did, V: varsig::Header<C>, C: Codec + TryFrom<u64> + Into<u64>>
-    did::Verifiable<DID> for Receipt<T, DID, V, C>
+impl<T: Responds, DID: Did, V: varsig::Header<C>, C: Codec> did::Verifiable<DID>
+    for Receipt<T, DID, V, C>
 {
     fn verifier(&self) -> &DID {
         &self.payload.verifier()
     }
 }
 
-impl<
-        T: Responds + Clone,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > From<Receipt<T, DID, V, C>> for Ipld
+impl<T: Responds + Clone, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec>
+    From<Receipt<T, DID, V, C>> for Ipld
 where
     Ipld: From<T::Success>,
     Payload<T, DID>: TryFrom<arguments::Named<Ipld>>,
@@ -60,12 +56,8 @@ where
     }
 }
 
-impl<
-        T: Responds + Clone,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Envelope for Receipt<T, DID, V, C>
+impl<T: Responds + Clone, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Envelope
+    for Receipt<T, DID, V, C>
 where
     Ipld: From<T::Success>,
     Payload<T, DID>: TryFrom<arguments::Named<Ipld>>,
@@ -105,12 +97,8 @@ where
     }
 }
 
-impl<
-        T: Responds + Clone,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Serialize for Receipt<T, DID, V, C>
+impl<T: Responds + Clone, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> Serialize
+    for Receipt<T, DID, V, C>
 where
     Ipld: From<T::Success>,
     Payload<T, DID>: TryFrom<arguments::Named<Ipld>>,
@@ -123,13 +111,8 @@ where
     }
 }
 
-impl<
-        'de,
-        T: Responds + Clone,
-        DID: Did + Clone,
-        V: varsig::Header<C> + Clone,
-        C: Codec + TryFrom<u64> + Into<u64>,
-    > Deserialize<'de> for Receipt<T, DID, V, C>
+impl<'de, T: Responds + Clone, DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec>
+    Deserialize<'de> for Receipt<T, DID, V, C>
 where
     Ipld: From<T::Success>,
     Payload<T, DID>: TryFrom<arguments::Named<Ipld>>,

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -28,7 +28,7 @@ pub struct Receipt<
     T: Responds,
     DID: Did = did::preset::Verifier,
     V: varsig::Header<C> = varsig::header::Preset,
-    C: Codec + Into<u64> + TryFrom<u64> = varsig::encoding::Preset,
+    C: Codec = varsig::encoding::Preset,
 > {
     pub varsig_header: V,
     pub signature: DID::Signature,

--- a/src/receipt/store/memory.rs
+++ b/src/receipt/store/memory.rs
@@ -10,19 +10,15 @@ use std::{collections::BTreeMap, convert::Infallible, fmt};
 
 /// An in-memory [`receipt::Store`][crate::receipt::Store].
 #[derive(Debug, Clone, PartialEq)]
-pub struct MemoryStore<
-    T: Responds,
-    DID: Did,
-    V: varsig::Header<Enc>,
-    Enc: Codec + Into<u64> + TryFrom<u64>,
-> where
+pub struct MemoryStore<T: Responds, DID: Did, V: varsig::Header<Enc>, Enc: Codec>
+where
     T::Success: fmt::Debug + Clone + PartialEq,
 {
     store: BTreeMap<task::Id, Receipt<T, DID, V, Enc>>,
 }
 
-impl<T: Responds, DID: Did, V: varsig::Header<Enc>, Enc: Codec + Into<u64> + TryFrom<u64>>
-    Store<T, DID, V, Enc> for MemoryStore<T, DID, V, Enc>
+impl<T: Responds, DID: Did, V: varsig::Header<Enc>, Enc: Codec> Store<T, DID, V, Enc>
+    for MemoryStore<T, DID, V, Enc>
 where
     <T as Responds>::Success: TryFrom<Ipld> + Into<Ipld> + Clone + fmt::Debug + PartialEq,
 {

--- a/src/receipt/store/traits.rs
+++ b/src/receipt/store/traits.rs
@@ -7,7 +7,7 @@ use crate::{
 use libipld_core::{codec::Codec, ipld::Ipld};
 
 /// A store for [`Receipt`]s indexed by their [`task::Id`]s.
-pub trait Store<T: Responds, DID: Did, V: varsig::Header<C>, C: Codec + Into<u64> + TryFrom<u64>> {
+pub trait Store<T: Responds, DID: Did, V: varsig::Header<C>, C: Codec> {
     /// The error type representing all the ways a store operation can fail.
     type Error;
 


### PR DESCRIPTION
Removes some unused constraints from type signatures:
- the ability type doesn't need `Deserialize` in `Deserialize for Payload`, because it actually uses `ParseAbility::try_parse` to parse, so `ParseAbility` is enough.
- `Codec + TryFrom<u64> + Into<u64>` is as good as `Codec`, because it's defined as `trait Codec: [...] TryFrom<u64, Error = UnsupportedCodec> + Into<u64>`.
- there was an unused `<S as delegation::store::Store<...>>::DelegationStoreError: Debug` constraint (it's part of the trait)
- I took the freedom to also make `type InvocationStoreError: Debug` in the invocation store, similar to the delegation store, and removed the constraints used elsewhere.