### PR TITLE
Rename `CannotCidOr`, API for creating powerlines & more

### DIFF
--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -92,6 +92,16 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
         &self.payload.audience
     }
 
+    /// Retrieve the `via` of a [`Delegation`]
+    pub fn via(&self) -> &Option<DID> {
+        &self.payload.via
+    }
+
+    /// Retrieve the `command` of a [`Delegation`]
+    pub fn command(&self) -> &String {
+        &self.payload.command
+    }
+
     /// Retrive the `policy` of a [`Delegation`]
     pub fn policy(&self) -> &Vec<Predicate> {
         &self.payload.policy

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -113,7 +113,7 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 
     /// Retrive the `expiration` of a [`Delegation`]
-    pub fn expiration(&self) -> &Timestamp {
+    pub fn expiration(&self) -> &Option<Timestamp> {
         &self.payload.expiration
     }
 

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -21,15 +21,14 @@ mod payload;
 pub use agent::Agent;
 pub use payload::*;
 
-use crate::ability::arguments::Named;
 use crate::{
+    ability::arguments::Named,
     capsule::Capsule,
     crypto::{signature::Envelope, varsig, Nonce},
     did::{self, Did},
     time::{TimeBoundError, Timestamp},
 };
-use libipld_core::link::Link;
-use libipld_core::{codec::Codec, ipld::Ipld};
+use libipld_core::{codec::Codec, ipld::Ipld, link::Link};
 use policy::Predicate;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -123,8 +122,8 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 
     /// Retrive the `expiration` of a [`Delegation`]
-    pub fn expiration(&self) -> &Option<Timestamp> {
-        &self.payload.expiration
+    pub fn expiration(&self) -> Option<&Timestamp> {
+        self.payload.expiration.as_ref()
     }
 
     pub fn check_time(&self, now: SystemTime) -> Result<(), TimeBoundError> {

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -82,8 +82,8 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 
     /// Retrive the `subject` of a [`Delegation`]
-    pub fn subject(&self) -> &Option<DID> {
-        &self.payload.subject
+    pub fn subject(&self) -> Option<&DID> {
+        self.payload.subject.as_ref()
     }
 
     /// Retrive the `audience` of a [`Delegation`]
@@ -92,8 +92,8 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 
     /// Retrieve the `via` of a [`Delegation`]
-    pub fn via(&self) -> &Option<DID> {
-        &self.payload.via
+    pub fn via(&self) -> Option<&DID> {
+        self.payload.via.as_ref()
     }
 
     /// Retrieve the `command` of a [`Delegation`]

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -67,7 +67,7 @@ where
         not_before: Option<Timestamp>,
         now: SystemTime,
         varsig_header: V,
-    ) -> Result<Delegation<DID, V, C>, DelegateError<S::DelegationStoreError>> {
+    ) -> Result<Delegation<DID, V, C>, DelegateError<S::Error>> {
         let mut salt = self.did.clone().to_string().into_bytes();
         let nonce = Nonce::generate_16();
 
@@ -118,7 +118,7 @@ where
         &self,
         cid: Cid, // FIXME remove and generate from the capsule header?
         delegation: Delegation<DID, V, C>,
-    ) -> Result<(), ReceiveError<S::DelegationStoreError, DID>> {
+    ) -> Result<(), ReceiveError<S::Error, DID>> {
         if self.store.get(&cid).is_ok() {
             return Ok(());
         }

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -63,7 +63,7 @@ where
         command: String,
         new_policy: Vec<Predicate>,
         metadata: BTreeMap<String, Ipld>,
-        expiration: Timestamp,
+        expiration: Option<Timestamp>,
         not_before: Option<Timestamp>,
         now: SystemTime,
         varsig_header: V,
@@ -96,8 +96,8 @@ where
             command,
             metadata,
             nonce,
-            expiration: expiration.into(),
-            not_before: not_before.map(Into::into),
+            expiration,
+            not_before,
             policy,
         };
 

--- a/src/delegation/store.rs
+++ b/src/delegation/store.rs
@@ -4,4 +4,4 @@ mod memory;
 mod traits;
 
 pub use memory::MemoryStore;
-pub use traits::Store;
+pub use traits::*;

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -332,7 +332,6 @@ mod tests {
                 .issuer(did.clone())
                 .audience(did.clone())
                 .command("/".into())
-                .expiration(crate::time::Timestamp::five_years_from_now())
                 .build()?,
         )?;
 
@@ -361,7 +360,6 @@ mod tests {
                 .issuer(did.clone())
                 .audience(did.clone())
                 .command("/".into())
-                .expiration(crate::time::Timestamp::five_years_from_now())
                 .build()?,
         )?;
 
@@ -420,7 +418,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -452,7 +449,6 @@ mod tests {
                     .issuer(bob.clone())
                     .audience(carol.clone())
                     .command("/example".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -466,7 +462,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -480,7 +475,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(carol.clone())
                     .command("/test".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -512,7 +506,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -526,7 +519,6 @@ mod tests {
                     .issuer(bob.clone())
                     .audience(carol.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -568,7 +560,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/test".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -582,7 +573,6 @@ mod tests {
                     .issuer(bob.clone())
                     .audience(carol.clone())
                     .command("/test/me".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -631,7 +621,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/test".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -645,7 +634,6 @@ mod tests {
                     .issuer(carol.clone())
                     .audience(dan.clone())
                     .command("/test/me".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -692,7 +680,6 @@ mod tests {
                     .issuer(bob.clone())
                     .audience(carol.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -705,7 +692,6 @@ mod tests {
                     .issuer(carol.clone())
                     .audience(dave.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?, // I don't love this is now failable
             )?;
 
@@ -718,7 +704,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -776,7 +761,6 @@ mod tests {
                     .issuer(bob.clone())
                     .audience(carol.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -789,7 +773,6 @@ mod tests {
                     .issuer(carol.clone())
                     .audience(dave.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?, // I don't love this is now failable
             )?;
 
@@ -802,7 +785,6 @@ mod tests {
                     .issuer(alice.clone())
                     .audience(bob.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -144,12 +144,9 @@ where
     delegation::Payload<DID>: TryFrom<Named<Ipld>>,
     Ipld: Encode<Enc>,
 {
-    type DelegationStoreError = Infallible;
+    type Error = Infallible;
 
-    fn get(
-        &self,
-        cid: &Cid,
-    ) -> Result<Option<Arc<Delegation<DID, V, Enc>>>, Self::DelegationStoreError> {
+    fn get(&self, cid: &Cid) -> Result<Option<Arc<Delegation<DID, V, Enc>>>, Self::Error> {
         // cheap Arc clone
         Ok(self.lock().ucans.get(cid).cloned())
         // FIXME
@@ -159,7 +156,7 @@ where
         &self,
         cid: Cid,
         delegation: Delegation<DID, V, Enc>,
-    ) -> Result<(), Self::DelegationStoreError> {
+    ) -> Result<(), Self::Error> {
         let mut tx = self.lock();
 
         tx.index
@@ -174,7 +171,7 @@ where
         Ok(())
     }
 
-    fn revoke(&self, cid: Cid) -> Result<(), Self::DelegationStoreError> {
+    fn revoke(&self, cid: Cid) -> Result<(), Self::Error> {
         self.lock().revocations.insert(cid);
         Ok(())
     }
@@ -186,8 +183,7 @@ where
         command: &str,
         policy: Vec<Predicate>, // FIXME
         now: SystemTime,
-    ) -> Result<Option<NonEmpty<(Cid, Arc<Delegation<DID, V, Enc>>)>>, Self::DelegationStoreError>
-    {
+    ) -> Result<Option<NonEmpty<(Cid, Arc<Delegation<DID, V, Enc>>)>>, Self::Error> {
         let blank_set = BTreeSet::new();
         let blank_map = BTreeMap::new();
         let tx = self.lock();

--- a/src/delegation/store/traits.rs
+++ b/src/delegation/store/traits.rs
@@ -27,9 +27,9 @@ where
     fn insert(
         &self,
         delegation: Delegation<DID, V, C>,
-    ) -> Result<(), DelegationStoreError<Self::Error>> {
+    ) -> Result<(), DelegationInsertError<Self::Error>> {
         self.insert_keyed(delegation.cid()?, delegation)
-            .map_err(DelegationStoreError::StoreError)
+            .map_err(DelegationInsertError::StoreError)
     }
 
     fn insert_keyed(&self, cid: Cid, delegation: Delegation<DID, V, C>) -> Result<(), Self::Error>;
@@ -116,7 +116,7 @@ where
 }
 
 #[derive(Debug, Error)]
-pub enum DelegationStoreError<E> {
+pub enum DelegationInsertError<E> {
     #[error("Cannot make CID from delegation based on supplied Varsig")]
     CannotMakeCid(#[from] libipld_core::error::Error),
 

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -650,7 +650,6 @@ mod tests {
                     .issuer(account.clone())
                     .audience(server.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 
@@ -663,7 +662,6 @@ mod tests {
                     .issuer(server.clone())
                     .audience(device.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?, // I don't love this is now failable
             )?;
 
@@ -676,7 +674,6 @@ mod tests {
                     .issuer(dnslink.clone())
                     .audience(account.clone())
                     .command("/".into())
-                    .expiration(crate::time::Timestamp::five_years_from_now())
                     .build()?,
             )?;
 

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -97,7 +97,7 @@ where
         issued_at: Option<Timestamp>,
         now: SystemTime,
         varsig_header: V,
-    ) -> Result<Invocation<T, DID, V, C>, InvokeError<D::DelegationStoreError>> {
+    ) -> Result<Invocation<T, DID, V, C>, InvokeError<D::Error>> {
         let proofs = if subject == self.did {
             vec![]
         } else {
@@ -175,7 +175,7 @@ where
     pub fn receive(
         &self,
         invocation: Invocation<T, DID, V, C>,
-    ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::DelegationStoreError, S, V, C>>
+    ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::Error, S, V, C>>
     where
         arguments::Named<Ipld>: From<T>,
         Payload<T, DID>: TryFrom<Named<Ipld>>,
@@ -188,7 +188,7 @@ where
         &self,
         invocation: Invocation<T, DID, V, C>,
         now: SystemTime,
-    ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::DelegationStoreError, S, V, C>>
+    ) -> Result<Recipient<Payload<T, DID>>, ReceiveError<T, DID, D::Error, S, V, C>>
     where
         arguments::Named<Ipld>: From<T>,
         Payload<T, DID>: TryFrom<Named<Ipld>>,
@@ -219,7 +219,7 @@ where
                     .ok_or(ReceiveError::DelegationNotFound(*cid))?
                     .payload)
             })
-            .collect::<Result<_, ReceiveError<T, DID, D::DelegationStoreError, S, V, C>>>()?;
+            .collect::<Result<_, ReceiveError<T, DID, D::Error, S, V, C>>>()?;
 
         let _ = &invocation
             .payload
@@ -300,7 +300,7 @@ pub enum ReceiveError<T, DID: Did, D, S: Store<T, DID, V, C>, V: varsig::Header<
     SigVerifyError(#[from] signature::ValidateError),
 
     #[error("invocation store error: {0}")]
-    InvocationStoreError(#[source] <S as Store<T, DID, V, C>>::InvocationStoreError),
+    InvocationStoreError(#[source] <S as Store<T, DID, V, C>>::Error),
 
     #[error("delegation store error: {0}")]
     DelegationStoreError(#[source] D),

--- a/src/invocation/payload.rs
+++ b/src/invocation/payload.rs
@@ -188,8 +188,10 @@ impl<A, DID: Did> Payload<A, DID> {
                     }
                 }
 
-                if proof.expiration < now_ts {
-                    return Err(ValidationError::Expired.into());
+                if let Some(exp) = proof.expiration {
+                    if exp < now_ts {
+                        return Err(ValidationError::Expired.into());
+                    }
                 }
 
                 if let Some(nbf) = proof.not_before.clone() {

--- a/src/invocation/store/memory.rs
+++ b/src/invocation/store/memory.rs
@@ -49,20 +49,13 @@ impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec> Default for MemoryStore<T,
 impl<T, DID: Did, V: varsig::Header<Enc>, Enc: Codec> Store<T, DID, V, Enc>
     for MemoryStore<T, DID, V, Enc>
 {
-    type InvocationStoreError = Infallible;
+    type Error = Infallible;
 
-    fn get(
-        &self,
-        cid: Cid,
-    ) -> Result<Option<Arc<Invocation<T, DID, V, Enc>>>, Self::InvocationStoreError> {
+    fn get(&self, cid: Cid) -> Result<Option<Arc<Invocation<T, DID, V, Enc>>>, Self::Error> {
         Ok(self.lock().store.get(&cid).cloned())
     }
 
-    fn put(
-        &self,
-        cid: Cid,
-        invocation: Invocation<T, DID, V, Enc>,
-    ) -> Result<(), Self::InvocationStoreError> {
+    fn put(&self, cid: Cid, invocation: Invocation<T, DID, V, Enc>) -> Result<(), Self::Error> {
         self.lock().store.insert(cid, Arc::new(invocation));
         Ok(())
     }

--- a/src/invocation/store/traits.rs
+++ b/src/invocation/store/traits.rs
@@ -3,20 +3,13 @@ use libipld_core::{cid::Cid, codec::Codec};
 use std::{fmt::Debug, sync::Arc};
 
 pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec> {
-    type InvocationStoreError: Debug;
+    type Error: Debug;
 
-    fn get(
-        &self,
-        cid: Cid,
-    ) -> Result<Option<Arc<Invocation<T, DID, V, C>>>, Self::InvocationStoreError>;
+    fn get(&self, cid: Cid) -> Result<Option<Arc<Invocation<T, DID, V, C>>>, Self::Error>;
 
-    fn put(
-        &self,
-        cid: Cid,
-        invocation: Invocation<T, DID, V, C>,
-    ) -> Result<(), Self::InvocationStoreError>;
+    fn put(&self, cid: Cid, invocation: Invocation<T, DID, V, C>) -> Result<(), Self::Error>;
 
-    fn has(&self, cid: Cid) -> Result<bool, Self::InvocationStoreError> {
+    fn has(&self, cid: Cid) -> Result<bool, Self::Error> {
         Ok(self.get(cid).is_ok())
     }
 }
@@ -24,23 +17,13 @@ pub trait Store<T, DID: Did, V: varsig::Header<C>, C: Codec> {
 impl<S: Store<T, DID, V, C>, T, DID: Did, V: varsig::Header<C>, C: Codec> Store<T, DID, V, C>
     for &S
 {
-    type InvocationStoreError = <S as Store<T, DID, V, C>>::InvocationStoreError;
+    type Error = <S as Store<T, DID, V, C>>::Error;
 
-    fn get(
-        &self,
-        cid: Cid,
-    ) -> Result<
-        Option<Arc<Invocation<T, DID, V, C>>>,
-        <S as Store<T, DID, V, C>>::InvocationStoreError,
-    > {
+    fn get(&self, cid: Cid) -> Result<Option<Arc<Invocation<T, DID, V, C>>>, Self::Error> {
         (**self).get(cid)
     }
 
-    fn put(
-        &self,
-        cid: Cid,
-        invocation: Invocation<T, DID, V, C>,
-    ) -> Result<(), <S as Store<T, DID, V, C>>::InvocationStoreError> {
+    fn put(&self, cid: Cid, invocation: Invocation<T, DID, V, C>) -> Result<(), Self::Error> {
         (**self).put(cid, invocation)
     }
 }


### PR DESCRIPTION
- Renamed the associated types `DelegationStoreError` and `InvocationStoreError` into just `Error`. They're namespaced by the trait anyways, and is a [common pattern in rust](https://docs.rs/serde/latest/serde/trait.Deserializer.html)
- Renamed `CannotCidOr` to `DelegationInsertError`

Also, previously, given a `delegation::Agent`, there was no way to create a powerline. The `Agent::signer` is private, so it can't be used with `Delegation::try_sign` directly.
I get the fact that `store.get_chain` shouldn't take a `subject: Option<DID>`, but I think `Agent::delegate` *should*.
I needed that to keep creating powerlines from the fission-server crate.

---

And more things:
- Made `expiration` optional (although we're still discussing)
- Refactored to use let-else in `Envelope::try_from_ipld_envelope`
- Fixed and made use of `Envelope::varsig_encode` (I needed some API for getting a byte representation of a UCAN, and I think that's probably the best function?)
- Created missing `via` and `command` functions for accessing those `Payload` fields