### PR TITLE
Add Delegation Builder

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,25 +19,6 @@
         "type": "github"
       }
     },
-    "devshell": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1711099426,
-        "narHash": "sha256-HzpgM/wc3aqpnHJJ2oDqPBkNsqWbW0WfWUO8lKu8nGk=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "2d45b54ca4a183f2fdcf4b19c895b64fbf620ee8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -60,24 +41,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -93,11 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1711616573,
-        "narHash": "sha256-FvZiEl6D4iLXqSQ3oGjQ/qehhPZ5E7iTHr/YA1Rw8kY=",
+        "lastModified": 1722892243,
+        "narHash": "sha256-E0CKe8EJfdEA0Td/Z79AHpYuWg8H8U6RFUxaEaRVHdc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c99b66784962e8984444b4d9e72d00d3549afdb2",
+        "rev": "54a75f91a509dec6e474c9336830af230fce8d1a",
         "type": "github"
       },
       "original": {
@@ -123,60 +86,40 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "lastModified": 1722791413,
+        "narHash": "sha256-rCTrlCWvHzMCNcKxPE3Z/mMK2gDZ+BvvpEVyRM4tKmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1711460390,
-        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
+        "rev": "8b5b6723aca5a51edf075936439d9cd3947b7b2c",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },
     "root": {
       "inputs": {
         "command-utils": "command-utils",
-        "devshell": "devshell",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixos-unstable": "nixos-unstable",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1711592024,
-        "narHash": "sha256-oD4OJ3TRmVrbAuKZWxElRCyCagNCDuhfw2exBmNOy48=",
+        "lastModified": 1722910815,
+        "narHash": "sha256-v6Vk/xlABhw2QzOa6xh3Jx/IvmlbKbOazFM+bDFQlWU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa858717377db2ed8ffd2d44147d907baee656e5",
+        "rev": "7df2ac544c203d21b63aac23bfaec7f9b919a733",
         "type": "github"
       },
       "original": {
@@ -201,21 +144,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,11 @@
   description = "ucan";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
     nixos-unstable.url = "nixpkgs/nixos-unstable-small";
 
     command-utils.url = "github:expede/nix-command-utils";
-
     flake-utils.url = "github:numtide/flake-utils";
-    devshell.url = "github:numtide/devshell";
 
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -19,7 +17,6 @@
 
   outputs = {
     self,
-    devshell,
     flake-utils,
     nixos-unstable,
     nixpkgs,
@@ -29,7 +26,6 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         overlays = [
-          devshell.overlays.default
           (import rust-overlay)
         ];
 
@@ -102,7 +98,7 @@
           "release:host" = cmd "Build release for ${system}"
             "${cargo} build --release";
 
-          "release:wasm:web" = cmd "Build release for wasm32-unknown-unknown with web bindings"
+         "release:wasm:web" = cmd "Build release for wasm32-unknown-unknown with web bindings"
             "${wasm-pack} build --release --target=web";
 
           "release:wasm:nodejs" = cmd "Build release for wasm32-unknown-unknown with Node.js bindgings"
@@ -115,7 +111,7 @@
 
           "build:wasm:web" = cmd "Build for wasm32-unknown-unknown with web bindings"
             "${wasm-pack} build --dev --target=web";
-
+ 
           "build:wasm:nodejs" = cmd "Build for wasm32-unknown-unknown with Node.js bindgings"
             "${wasm-pack} build --dev --target=nodejs";
 
@@ -174,7 +170,7 @@
             "test:host && test:docs && test:wasm";
 
           "test:host" = cmd "Run Cargo tests for host target"
-            "${cargo} test --features=test_utils";
+            "${cargo} test --features=mermaid_docs,test_utils";
 
           "test:wasm" = cmd "Run wasm-pack tests on all targets"
             "test:wasm:node && test:wasm:chrome";
@@ -220,7 +216,6 @@
               self.packages.${system}.irust
               (pkgs.hiPrio pkgs.rust-bin.nightly.latest.rustfmt)
 
-              pre-commit
               pkgs.wasm-pack
               chromedriver
               protobuf
@@ -234,8 +229,6 @@
             ++ lib.optionals stdenv.isDarwin darwin-installs;
 
           shellHook = ''
-            [ -e .git/hooks/pre-commit ] || pre-commit install --install-hooks && pre-commit install --hook-type commit-msg
-
             export RUSTC_WRAPPER="${pkgs.sccache}/bin/sccache"
             unset SOURCE_DATE_EPOCH
           ''

--- a/src/crypto/signature/envelope.rs
+++ b/src/crypto/signature/envelope.rs
@@ -89,29 +89,6 @@ pub trait Envelope: Sized {
         Ok(w)
     }
 
-    /// Attempt to sign some payload with a given signer.
-    ///
-    /// # Arguments
-    ///
-    /// * `signer` - The signer to use to sign the payload.
-    /// * `payload` - The payload to sign.
-    ///
-    /// # Errors
-    ///
-    /// * [`SignError`] - the payload can't be encoded or the signature fails.
-    // FIXME ported
-    fn try_sign(
-        signer: &<Self::DID as Did>::Signer,
-        varsig_header: Self::VarsigHeader,
-        payload: Self::Payload,
-    ) -> Result<Self, SignError>
-    where
-        Ipld: Encode<Self::Encoder>,
-        Named<Ipld>: From<Self::Payload>,
-    {
-        Self::try_sign_generic(signer, varsig_header, payload)
-    }
-
     /// Attempt to sign some payload with a given signer and specific codec.
     ///
     /// # Arguments
@@ -126,7 +103,7 @@ pub trait Envelope: Sized {
     ///
     /// # Example
     ///
-    fn try_sign_generic(
+    fn try_sign(
         signer: &<Self::DID as Did>::Signer,
         varsig_header: Self::VarsigHeader,
         payload: Self::Payload,

--- a/src/crypto/varsig/header/preset.rs
+++ b/src/crypto/varsig/header/preset.rs
@@ -100,7 +100,7 @@ impl Header<encoding::Preset> for Preset {
             Preset::Es256(es256) => es256.codec(),
             Preset::Es256k(es256k) => es256k.codec(),
             Preset::Es512(es512) => es512.codec(),
-            // Preset::Bls
+            // Preset::Bls FIXME
         }
     }
 }

--- a/src/crypto/varsig/header/preset.rs
+++ b/src/crypto/varsig/header/preset.rs
@@ -100,7 +100,7 @@ impl Header<encoding::Preset> for Preset {
             Preset::Es256(es256) => es256.codec(),
             Preset::Es256k(es256k) => es256k.codec(),
             Preset::Es512(es512) => es512.codec(),
-            // Preset::Bls FIXME
+            // Preset::Bls
         }
     }
 }

--- a/src/crypto/varsig/header/traits.rs
+++ b/src/crypto/varsig/header/traits.rs
@@ -2,13 +2,13 @@ use libipld_core::codec::{Codec, Encode};
 use signature::Verifier;
 use thiserror::Error;
 
-pub trait Header<Enc: Codec>: for<'a> TryFrom<&'a [u8]> + Into<Vec<u8>> {
+pub trait Header<C: Codec>: for<'a> TryFrom<&'a [u8]> + Into<Vec<u8>> {
     type Signature: signature::SignatureEncoding;
     type Verifier: signature::Verifier<Self::Signature>;
 
-    fn codec(&self) -> &Enc;
+    fn codec(&self) -> &C;
 
-    fn encode_payload<T: Encode<Enc>, Buf: std::io::Write>(
+    fn encode_payload<T: Encode<C>, Buf: std::io::Write>(
         &self,
         payload: T,
         buffer: &mut Buf,
@@ -16,7 +16,7 @@ pub trait Header<Enc: Codec>: for<'a> TryFrom<&'a [u8]> + Into<Vec<u8>> {
         payload.encode(Self::codec(self).clone(), buffer)
     }
 
-    fn try_verify<'a, T: Encode<Enc>>(
+    fn try_verify<'a, T: Encode<C>>(
         &self,
         verifier: &'a Self::Verifier,
         signature: &'a Self::Signature,

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -37,6 +37,7 @@ use libipld_core::{
 use policy::Predicate;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
 use web_time::SystemTime;
 
 /// A [`Delegation`] is a signed delegation [`Payload`]
@@ -51,7 +52,7 @@ pub struct Delegation<
     pub varsig_header: V,
     pub payload: Payload<DID>,
     pub signature: DID::Signature,
-    _marker: std::marker::PhantomData<C>,
+    _marker: PhantomData<C>,
 }
 
 pub struct DelegationRequired<
@@ -64,7 +65,7 @@ pub struct DelegationRequired<
     pub audience: DID,
     pub command: String,
 
-    pub codec: C,
+    pub codec: PhantomData<C>,
     pub varsig_header: V,
     pub signer: DID::Signer,
 }
@@ -74,21 +75,21 @@ pub struct DelegationBuilder<
     V: varsig::Header<C> = varsig::header::Preset,
     C: Codec = varsig::encoding::Preset,
 > {
-    pub subject: Subject<DID>,
-    pub issuer: DID,
-    pub audience: DID,
-    pub command: String,
+    subject: Subject<DID>,
+    issuer: DID,
+    audience: DID,
+    command: String,
 
-    pub codec: C,
-    pub varsig_header: V,
-    pub signer: DID::Signer,
+    codec: PhantomData<C>,
+    varsig_header: V,
+    signer: DID::Signer,
 
-    pub via: Option<DID>,
-    pub policy: Vec<Predicate>,
-    pub metadata: BTreeMap<String, Ipld>,
-    pub nonce: Option<Nonce>,
-    pub expiration: Option<Timestamp>,
-    pub not_before: Option<Timestamp>,
+    via: Option<DID>,
+    policy: Vec<Predicate>,
+    metadata: BTreeMap<String, Ipld>,
+    nonce: Option<Nonce>,
+    expiration: Option<Timestamp>,
+    not_before: Option<Timestamp>,
 }
 
 impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> DelegationRequired<DID, V, C>
@@ -122,7 +123,6 @@ where
         self.to_builder().try_finalize()
     }
 
-    /// Set the `via` field of the [`Delegation`]
     pub fn with_via(self, via: DID) -> DelegationBuilder<DID, V, C> {
         let builder = self.to_builder();
         builder.with_via(via)
@@ -238,7 +238,7 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
             varsig_header,
             payload,
             signature,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 
@@ -316,7 +316,7 @@ where
             varsig_header,
             payload,
             signature,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 
@@ -397,7 +397,7 @@ mod tests {
                 command: "/".to_string(),
 
                 signer: alice_signer,
-                codec: encoding::Preset::DagCbor,
+                codec: PhantomData,
                 varsig_header: header::Preset::EdDsa(header::EdDsaHeader {
                     codec: encoding::Preset::DagCbor,
                 }),
@@ -427,7 +427,7 @@ mod tests {
                 command: "/".to_string(),
 
                 signer: alice_signer,
-                codec: encoding::Preset::DagCbor,
+                codec: PhantomData,
                 varsig_header: header::Preset::EdDsa(header::EdDsaHeader {
                     codec: encoding::Preset::DagCbor,
                 }),

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -28,7 +28,12 @@ use crate::{
     did::{self, Did},
     time::{TimeBoundError, Timestamp},
 };
-use libipld_core::{codec::Codec, ipld::Ipld, link::Link};
+use core::str::FromStr;
+use libipld_core::{
+    codec::{Codec, Encode},
+    ipld::Ipld,
+    link::Link,
+};
 use policy::Predicate;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -47,6 +52,167 @@ pub struct Delegation<
     pub payload: Payload<DID>,
     pub signature: DID::Signature,
     _marker: std::marker::PhantomData<C>,
+}
+
+pub struct DelegationRequired<
+    DID: Did = did::preset::Verifier,
+    V: varsig::Header<C> = varsig::header::Preset,
+    C: Codec = varsig::encoding::Preset,
+> {
+    pub subject: Subject<DID>,
+    pub issuer: DID,
+    pub audience: DID,
+    pub command: String,
+
+    pub codec: C,
+    pub varsig_header: V,
+    pub signer: DID::Signer,
+}
+
+pub struct DelegationBuilder<
+    DID: Did = did::preset::Verifier,
+    V: varsig::Header<C> = varsig::header::Preset,
+    C: Codec = varsig::encoding::Preset,
+> {
+    pub subject: Subject<DID>,
+    pub issuer: DID,
+    pub audience: DID,
+    pub command: String,
+
+    pub codec: C,
+    pub varsig_header: V,
+    pub signer: DID::Signer,
+
+    pub via: Option<DID>,
+    pub policy: Vec<Predicate>,
+    pub metadata: BTreeMap<String, Ipld>,
+    pub nonce: Option<Nonce>,
+    pub expiration: Option<Timestamp>,
+    pub not_before: Option<Timestamp>,
+}
+
+impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> DelegationRequired<DID, V, C>
+where
+    Ipld: Encode<C>,
+{
+    pub fn to_builder(self) -> DelegationBuilder<DID, V, C> {
+        DelegationBuilder {
+            subject: self.subject,
+            issuer: self.issuer,
+            audience: self.audience,
+            command: self.command,
+
+            codec: self.codec,
+            varsig_header: self.varsig_header,
+            signer: self.signer,
+
+            via: None,
+            policy: vec![],
+            metadata: Default::default(),
+            nonce: None,
+            expiration: None,
+            not_before: None,
+        }
+    }
+
+    pub fn try_finalize(self) -> Result<Delegation<DID, V, C>, crate::crypto::signature::SignError>
+    where
+        <DID as FromStr>::Err: std::fmt::Debug,
+    {
+        self.to_builder().try_finalize()
+    }
+
+    /// Set the `via` field of the [`Delegation`]
+    pub fn with_via(self, via: DID) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_via(via)
+    }
+
+    pub fn with_policy(self, policy: Vec<Predicate>) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_policy(policy)
+    }
+
+    pub fn with_nonce(self, nonce: Nonce) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_nonce(nonce)
+    }
+
+    pub fn with_metadata(self, metadata: BTreeMap<String, Ipld>) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_metadata(metadata)
+    }
+
+    pub fn with_expiration(self, expiration: Timestamp) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_expiration(expiration)
+    }
+
+    pub fn with_not_before(self, not_before: Timestamp) -> DelegationBuilder<DID, V, C> {
+        let builder = self.to_builder();
+        builder.with_not_before(not_before)
+    }
+}
+
+impl<DID: Did + Clone, V: varsig::Header<C> + Clone, C: Codec> DelegationBuilder<DID, V, C>
+where
+    Ipld: Encode<C>,
+{
+    pub fn try_finalize(self) -> Result<Delegation<DID, V, C>, crate::crypto::signature::SignError>
+    where
+        <DID as FromStr>::Err: std::fmt::Debug,
+    {
+        let payload = Payload {
+            subject: self.subject,
+            issuer: self.issuer,
+            audience: self.audience,
+            via: None,
+
+            command: self.command,
+            policy: vec![],
+
+            nonce: Nonce::generate_16(),
+            metadata: Default::default(),
+
+            expiration: None,
+            not_before: None,
+        };
+
+        Delegation::try_sign(&self.signer, self.varsig_header, payload)
+    }
+
+    pub fn with_via(mut self, via: DID) -> DelegationBuilder<DID, V, C> {
+        self.via = Some(via);
+        self
+    }
+
+    pub fn with_policy(mut self, policy: Vec<Predicate>) -> DelegationBuilder<DID, V, C> {
+        self.policy = policy;
+        self
+    }
+
+    pub fn with_nonce(mut self, nonce: Nonce) -> DelegationBuilder<DID, V, C> {
+        self.nonce = Some(nonce);
+        self
+    }
+
+    pub fn with_metadata(
+        mut self,
+        metadata: BTreeMap<String, Ipld>,
+    ) -> DelegationBuilder<DID, V, C> {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn with_expiration(mut self, expiration: Timestamp) -> DelegationBuilder<DID, V, C> {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    pub fn with_not_before(mut self, not_before: Timestamp) -> DelegationBuilder<DID, V, C> {
+        self.not_before = Some(not_before);
+        self
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -82,8 +248,8 @@ impl<DID: Did, V: varsig::Header<C>, C: Codec> Delegation<DID, V, C> {
     }
 
     /// Retrive the `subject` of a [`Delegation`]
-    pub fn subject(&self) -> Option<&DID> {
-        self.payload.subject.as_ref()
+    pub fn subject(&self) -> &Subject<DID> {
+        &self.payload.subject
     }
 
     /// Retrive the `audience` of a [`Delegation`]
@@ -195,5 +361,88 @@ where
     {
         let ipld = Ipld::deserialize(deserializer)?;
         Self::try_from_ipld_envelope(ipld).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::varsig::{encoding, header};
+    use assert_matches::assert_matches;
+    use rand::thread_rng;
+    use std::collections::BTreeMap;
+    use testresult::TestResult;
+
+    fn gen_did() -> (crate::did::preset::Verifier, crate::did::preset::Signer) {
+        let sk = ed25519_dalek::SigningKey::generate(&mut thread_rng());
+        let verifier =
+            crate::did::preset::Verifier::Key(crate::did::key::Verifier::EdDsa(sk.verifying_key()));
+        let signer = crate::did::preset::Signer::Key(crate::did::key::Signer::EdDsa(sk));
+
+        (verifier, signer)
+    }
+
+    mod required {
+        use super::*;
+
+        fn fixture() -> DelegationRequired {
+            let (alice, alice_signer) = gen_did();
+            let (bob, bob_signer) = gen_did();
+            let (carol, carol_signer) = gen_did();
+
+            DelegationRequired {
+                subject: Subject::Any,
+                issuer: alice,
+                audience: bob,
+                command: "/".to_string(),
+
+                signer: alice_signer,
+                codec: encoding::Preset::DagCbor,
+                varsig_header: header::Preset::EdDsa(header::EdDsaHeader {
+                    codec: encoding::Preset::DagCbor,
+                }),
+            }
+        }
+
+        #[test_log::test]
+        fn test_finalize_always_works() -> TestResult {
+            let delegation = fixture().try_finalize();
+            assert_matches!(delegation, Ok(_));
+            Ok(())
+        }
+    }
+
+    mod builder {
+        use super::*;
+
+        fn fixture() -> Result<Delegation, crate::crypto::signature::SignError> {
+            let (alice, alice_signer) = gen_did();
+            let (bob, bob_signer) = gen_did();
+            let (carol, carol_signer) = gen_did();
+
+            DelegationRequired {
+                subject: Subject::Any,
+                issuer: alice,
+                audience: bob,
+                command: "/".to_string(),
+
+                signer: alice_signer,
+                codec: encoding::Preset::DagCbor,
+                varsig_header: header::Preset::EdDsa(header::EdDsaHeader {
+                    codec: encoding::Preset::DagCbor,
+                }),
+            }
+            .with_via(carol)
+            .with_policy(vec![])
+            .with_metadata(BTreeMap::from_iter([("foo".into(), 123.into())]))
+            .try_finalize()
+        }
+
+        #[test_log::test]
+        fn test_full_builder() -> TestResult {
+            let delegation = fixture();
+            assert_matches!(delegation, Ok(_));
+            Ok(())
+        }
     }
 }

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -2,6 +2,7 @@ use super::{payload::Payload, policy::Predicate, store::Store, Delegation};
 use crate::{
     ability::arguments::Named,
     crypto::{signature::Envelope, varsig, Nonce},
+    delegation::Subject,
     did,
     did::Did,
     time::Timestamp,
@@ -58,7 +59,7 @@ where
     pub fn delegate(
         &self,
         audience: DID,
-        subject: Option<&DID>,
+        subject: Subject<&DID>,
         via: Option<DID>,
         command: String,
         new_policy: Vec<Predicate>,
@@ -71,9 +72,11 @@ where
         let nonce = Nonce::generate_16();
 
         let (subject, policy) = match subject {
-            Some(subject) if *subject == self.did => (Some(subject.clone()), new_policy),
-            None => (None, new_policy),
-            Some(subject) => {
+            Subject::Specific(subject) if *subject == self.did => {
+                (Subject::Specific(subject.clone()), new_policy)
+            }
+            Subject::Any => (Subject::Any, new_policy),
+            Subject::Specific(subject) => {
                 let proofs = &self
                     .store
                     .get_chain(&self.did, &subject, &command, vec![], now)
@@ -83,7 +86,7 @@ where
 
                 let mut policy = to_delegate.policy.clone();
                 policy.extend(new_policy);
-                (Some(subject.clone()), policy)
+                (Subject::Specific(subject.clone()), policy)
             }
         };
 
@@ -101,6 +104,7 @@ where
         };
 
         Ok(Delegation::try_sign(&self.signer, varsig_header, payload).expect("FIXME"))
+        // FIXME
     }
 
     pub fn receive(

--- a/src/delegation/agent.rs
+++ b/src/delegation/agent.rs
@@ -72,11 +72,11 @@ where
         let nonce = Nonce::generate_16();
 
         let (subject, policy) = match subject {
-            Subject::Specific(subject) if *subject == self.did => {
-                (Subject::Specific(subject.clone()), new_policy)
+            Subject::Known(subject) if *subject == self.did => {
+                (Subject::Known(subject.clone()), new_policy)
             }
             Subject::Any => (Subject::Any, new_policy),
-            Subject::Specific(subject) => {
+            Subject::Known(subject) => {
                 let proofs = &self
                     .store
                     .get_chain(&self.did, &subject, &command, vec![], now)
@@ -86,7 +86,7 @@ where
 
                 let mut policy = to_delegate.policy.clone();
                 policy.extend(new_policy);
-                (Subject::Specific(subject.clone()), policy)
+                (Subject::Known(subject.clone()), policy)
             }
         };
 

--- a/src/delegation/payload.rs
+++ b/src/delegation/payload.rs
@@ -484,15 +484,8 @@ where
                     policy,
                     via,
                 )| {
-                    // FIXME use from instcane
-                    let subject = match maybe_subject {
-                        None => Subject::Any,
-                        Some(s) => Subject::Known(s),
-                    };
-
                     Payload {
                         issuer,
-                        subject,
                         audience,
                         command,
                         policy,
@@ -501,6 +494,10 @@ where
                         expiration,
                         not_before,
                         via,
+                        subject: match maybe_subject {
+                            None => Subject::Any,
+                            Some(s) => Subject::Known(s),
+                        },
                     }
                 },
             )

--- a/src/delegation/payload.rs
+++ b/src/delegation/payload.rs
@@ -8,7 +8,6 @@ use crate::{
     time::{TimeBoundError, Timestamp},
 };
 use core::str::FromStr;
-use derive_builder::Builder;
 use libipld_core::ipld::Ipld;
 use std::{collections::BTreeMap, fmt::Debug};
 use thiserror::Error;
@@ -24,7 +23,7 @@ use crate::ipld;
 ///
 /// This contains the semantic information about the delegation, including the
 /// issuer, subject, audience, the delegated ability, time bounds, and so on.
-#[derive(Debug, Clone, PartialEq, Builder)] // FIXME Serialize, Deserialize, Builder)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Payload<DID: Did> {
     /// The subject of the [`Delegation`].
     ///
@@ -36,7 +35,7 @@ pub struct Payload<DID: Did> {
     /// by the subject.
     ///
     /// [`Delegation`]: super::Delegation
-    pub subject: Option<DID>,
+    pub subject: Subject<DID>,
 
     /// The issuer of the [`Delegation`].
     ///
@@ -50,40 +49,100 @@ pub struct Payload<DID: Did> {
     pub audience: DID,
 
     /// A [`Did`] that must be in the delegation chain at invocation time.
-    #[builder(default)]
     pub via: Option<DID>,
 
     /// The command being delegated.
     pub command: String,
 
     /// Any [`Predicate`] policies that constrain the `args` on an [`Invocation`][crate::invocation::Invocation].
-    #[builder(default)]
     pub policy: Vec<Predicate>,
 
     /// Extensible, free-form fields.
-    #[builder(default)]
     pub metadata: BTreeMap<String, Ipld>,
 
     /// A [cryptographic nonce] to ensure that the UCAN's [`Cid`] is unique.
     ///
     /// [cryptograpgic nonce]: https://en.wikipedia.org/wiki/Cryptographic_nonce
     /// [`Cid`]: libipld_core::cid::Cid ;
-    #[builder(default = "Nonce::generate_16()")]
     pub nonce: Nonce,
 
     /// The latest wall-clock time that the UCAN is valid until,
     /// given as a [Unix timestamp].
     ///
     /// [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
-    #[builder(default)]
     pub expiration: Option<Timestamp>,
 
     /// An optional earliest wall-clock time that the UCAN is valid from,
     /// given as a [Unix timestamp].
     ///
     /// [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
-    #[builder(default)]
     pub not_before: Option<Timestamp>,
+}
+
+pub struct Required<DID> {
+    pub subject: Subject<DID>,
+    pub issuer: DID,
+    pub audience: DID,
+    pub command: String,
+}
+
+impl<DID: Did> From<Required<DID>> for Payload<DID> {
+    fn from(required: Required<DID>) -> Self {
+        Payload {
+            subject: required.subject,
+            issuer: required.issuer,
+            audience: required.audience,
+            command: required.command,
+            policy: vec![],
+            metadata: BTreeMap::new(),
+            nonce: Nonce::generate_16(),
+            expiration: None,
+            not_before: None,
+            via: None,
+        }
+    }
+}
+
+impl<DID: Did> Required<DID> {
+    pub fn build(self) -> Payload<DID> {
+        self.into()
+    }
+
+    pub fn with_via(self, via: Option<DID>) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.via = via;
+        payload
+    }
+
+    pub fn with_policy(self, policy: Vec<Predicate>) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.policy = policy;
+        payload
+    }
+
+    pub fn with_metadata(self, metadata: BTreeMap<String, Ipld>) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.metadata = metadata;
+        payload
+    }
+
+    pub fn with_nonce(self, nonce: Nonce) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.nonce = nonce;
+        payload
+    }
+
+    pub fn with_expiration(self, expiration: Option<Timestamp>) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.expiration = expiration;
+        payload
+    }
+
+    pub fn with_not_before(self, not_before: Option<Timestamp>) -> Payload<DID> {
+        let mut payload: Payload<DID> = self.into();
+        payload.not_before = not_before;
+        payload
+    }
 }
 
 impl<DID: Did> Payload<DID> {
@@ -103,6 +162,53 @@ impl<DID: Did> Payload<DID> {
         }
 
         Ok(())
+    }
+
+    pub fn with_via(&mut self, via: Option<DID>) -> &mut Payload<DID> {
+        self.via = via;
+        self
+    }
+
+    pub fn with_policy(&mut self, policy: Vec<Predicate>) -> &mut Payload<DID> {
+        self.policy = policy;
+        self
+    }
+
+    pub fn with_metadata(&mut self, metadata: BTreeMap<String, Ipld>) -> &mut Payload<DID> {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn with_nonce(&mut self, nonce: Nonce) -> &mut Payload<DID> {
+        self.nonce = nonce;
+        self
+    }
+
+    pub fn with_expiration(&mut self, expiration: Option<Timestamp>) -> &mut Payload<DID> {
+        self.expiration = expiration;
+        self
+    }
+
+    pub fn with_not_before(&mut self, not_before: Option<Timestamp>) -> &mut Payload<DID> {
+        self.not_before = not_before;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+pub enum Subject<DID> {
+    Specific(DID), // FIXME Known? also functor instacne
+    Any,
+}
+
+impl<DID: Ord> Ord for Subject<DID> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match (self, other) {
+            (Subject::Any, Subject::Any) => core::cmp::Ordering::Equal,
+            (Subject::Any, Subject::Specific(_)) => core::cmp::Ordering::Less,
+            (Subject::Specific(_), Subject::Any) => core::cmp::Ordering::Greater,
+            (Subject::Specific(a), Subject::Specific(b)) => a.cmp(b),
+        }
     }
 }
 
@@ -138,10 +244,10 @@ where
             match k.as_str() {
                 "sub" => {
                     subject = Some(match ipld {
-                        Ipld::Null => None,
-                        Ipld::String(s) => {
-                            Some(DID::from_str(s.as_str()).map_err(ParseError::DidParseError)?)
-                        }
+                        Ipld::Null => Subject::Any,
+                        Ipld::String(s) => Subject::Specific(
+                            DID::from_str(s.as_str()).map_err(ParseError::DidParseError)?,
+                        ),
                         bad => return Err(ParseError::WrongTypeForField("sub".to_string(), bad)),
                     })
                 }
@@ -318,7 +424,7 @@ impl<DID: Did> From<Payload<DID>> for Named<Ipld> {
             ),
         ]);
 
-        if let Some(subject) = payload.subject {
+        if let Subject::Specific(subject) = payload.subject {
             args.insert("sub".to_string(), Ipld::String(subject.to_string()));
         } else {
             args.insert("sub".to_string(), Ipld::Null);
@@ -367,7 +473,7 @@ where
         )
             .prop_map(
                 |(
-                    subject,
+                    maybe_subject,
                     issuer,
                     audience,
                     command,
@@ -378,6 +484,12 @@ where
                     policy,
                     via,
                 )| {
+                    // FIXME use from instcane
+                    let subject = match maybe_subject {
+                        None => Subject::Any,
+                        Some(s) => Subject::Specific(s),
+                    };
+
                     Payload {
                         issuer,
                         subject,
@@ -453,10 +565,10 @@ mod tests {
 
             // Optional Fields
             match (payload.subject, named.get("sub")) {
-                (Some(sub), Some(Ipld::String(s))) => {
+                (Subject::Specific(sub), Some(Ipld::String(s))) => {
                     prop_assert_eq!(&sub.to_string(), s);
                 }
-                (None, Some(Ipld::Null)) => prop_assert!(true),
+                (Subject::Any, Some(Ipld::Null)) => prop_assert!(true),
                 _ => prop_assert!(false)
             }
 

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -191,7 +191,7 @@ where
         let all_powerlines = tx.index.get(&Subject::Any).unwrap_or(&blank_map);
         let all_aud_for_subject = tx
             .index
-            .get(&Subject::Specific(subject.clone()))
+            .get(&Subject::Known(subject.clone()))
             .unwrap_or(&blank_map);
 
         let powerline_candidates = all_powerlines.get(aud).unwrap_or(&blank_set);
@@ -255,7 +255,7 @@ where
                         let issuer = delegation.issuer().clone();
 
                         // Hit a root delegation, AKA base case
-                        if Subject::Specific(issuer.clone()) == *delegation.subject() {
+                        if Subject::Known(issuer.clone()) == *delegation.subject() {
                             break 'outer;
                         }
 
@@ -526,7 +526,7 @@ mod tests {
                 &bob_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    subject: crate::delegation::Subject::Known(alice.clone()),
                     issuer: bob.clone(),
                     audience: carol.clone(),
                     command: "/".into(),
@@ -582,7 +582,7 @@ mod tests {
                 &bob_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    subject: crate::delegation::Subject::Known(alice.clone()),
                     issuer: bob.clone(),
                     audience: carol.clone(),
                     command: "/test/me".into(),
@@ -645,7 +645,7 @@ mod tests {
                 &carol_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    subject: crate::delegation::Subject::Known(alice.clone()),
                     issuer: carol.clone(),
                     audience: dan.clone(),
                     command: "/test/me".into(),
@@ -718,7 +718,7 @@ mod tests {
                 &alice_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    subject: crate::delegation::Subject::Known(alice.clone()),
                     issuer: alice.clone(),
                     audience: bob.clone(),
                     command: "/".into(),
@@ -802,7 +802,7 @@ mod tests {
                 &alice_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    subject: crate::delegation::Subject::Known(alice.clone()),
                     issuer: alice.clone(),
                     audience: bob.clone(),
                     command: "/".into(),

--- a/src/delegation/store/memory.rs
+++ b/src/delegation/store/memory.rs
@@ -3,7 +3,7 @@ use crate::ability::arguments::Named;
 use crate::delegation;
 use crate::{
     crypto::varsig,
-    delegation::{policy::Predicate, Delegation},
+    delegation::{policy::Predicate, Delegation, Subject},
     did::{self, Did},
 };
 use libipld_core::codec::Encode;
@@ -90,7 +90,7 @@ struct MemoryStoreInner<
     C: Codec = varsig::encoding::Preset,
 > {
     ucans: BTreeMap<Cid, Arc<Delegation<DID, V, C>>>,
-    index: BTreeMap<Option<DID>, BTreeMap<DID, BTreeSet<Cid>>>,
+    index: BTreeMap<Subject<DID>, BTreeMap<DID, BTreeSet<Cid>>>,
     revocations: BTreeSet<Cid>,
 }
 
@@ -160,7 +160,7 @@ where
         let mut tx = self.lock();
 
         tx.index
-            .entry(delegation.subject().cloned())
+            .entry(delegation.subject().clone())
             .or_default()
             .entry(delegation.audience().clone())
             .or_default()
@@ -188,8 +188,12 @@ where
         let blank_map = BTreeMap::new();
         let tx = self.lock();
 
-        let all_powerlines = tx.index.get(&None).unwrap_or(&blank_map);
-        let all_aud_for_subject = tx.index.get(&Some(subject.clone())).unwrap_or(&blank_map);
+        let all_powerlines = tx.index.get(&Subject::Any).unwrap_or(&blank_map);
+        let all_aud_for_subject = tx
+            .index
+            .get(&Subject::Specific(subject.clone()))
+            .unwrap_or(&blank_map);
+
         let powerline_candidates = all_powerlines.get(aud).unwrap_or(&blank_set);
         let sub_candidates = all_aud_for_subject.get(aud).unwrap_or(&blank_set);
 
@@ -251,7 +255,7 @@ where
                         let issuer = delegation.issuer().clone();
 
                         // Hit a root delegation, AKA base case
-                        if Some(&issuer) == delegation.subject() {
+                        if Subject::Specific(issuer.clone()) == *delegation.subject() {
                             break 'outer;
                         }
 
@@ -327,12 +331,13 @@ mod tests {
         let deleg = Delegation::try_sign(
             &signer,
             varsig_header,
-            crate::delegation::PayloadBuilder::default()
-                .subject(None)
-                .issuer(did.clone())
-                .audience(did.clone())
-                .command("/".into())
-                .build()?,
+            crate::delegation::Required {
+                subject: Subject::Any,
+                issuer: did.clone(),
+                audience: did.clone(),
+                command: "/".into(),
+            }
+            .into(),
         )?;
 
         store.insert(deleg.clone())?;
@@ -355,12 +360,13 @@ mod tests {
         let deleg = Delegation::try_sign(
             &signer,
             varsig_header,
-            crate::delegation::PayloadBuilder::default()
-                .subject(None)
-                .issuer(did.clone())
-                .audience(did.clone())
-                .command("/".into())
-                .build()?,
+            crate::delegation::Required {
+                subject: Subject::Any,
+                issuer: did.clone(),
+                audience: did.clone(),
+                command: "/".into(),
+            }
+            .into(),
         )?;
 
         store.insert(deleg.clone())?;
@@ -413,12 +419,13 @@ mod tests {
             let deleg = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg.clone())?;
@@ -444,12 +451,13 @@ mod tests {
             let noise = crate::Delegation::try_sign(
                 &bob_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(bob.clone())
-                    .audience(carol.clone())
-                    .command("/example".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: bob.clone(),
+                    audience: carol.clone(),
+                    command: "/example".into(),
+                }
+                .into(),
             )?;
 
             store.insert(noise.clone())?;
@@ -457,12 +465,13 @@ mod tests {
             let deleg = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg.clone())?;
@@ -470,12 +479,13 @@ mod tests {
             let more_noise = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(carol.clone())
-                    .command("/test".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: carol.clone(),
+                    command: "/test".into(),
+                }
+                .into(),
             )?;
 
             store.insert(more_noise.clone())?;
@@ -501,12 +511,13 @@ mod tests {
             let deleg_1 = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg_1.clone())?;
@@ -514,12 +525,13 @@ mod tests {
             let deleg_2 = crate::Delegation::try_sign(
                 &bob_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(alice.clone()))
-                    .issuer(bob.clone())
-                    .audience(carol.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    issuer: bob.clone(),
+                    audience: carol.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg_2.clone())?;
@@ -555,12 +567,13 @@ mod tests {
             let deleg_1 = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/test".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/test".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg_1.clone())?;
@@ -568,12 +581,13 @@ mod tests {
             let deleg_2 = crate::Delegation::try_sign(
                 &bob_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(alice.clone()))
-                    .issuer(bob.clone())
-                    .audience(carol.clone())
-                    .command("/test/me".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    issuer: bob.clone(),
+                    audience: carol.clone(),
+                    command: "/test/me".into(),
+                }
+                .into(),
             )?;
 
             store.insert(deleg_2.clone())?;
@@ -616,12 +630,13 @@ mod tests {
             let alice_to_bob = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/test".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/test".into(),
+                }
+                .into(),
             )?;
 
             store.insert(alice_to_bob.clone())?;
@@ -629,12 +644,13 @@ mod tests {
             let carol_to_dan = crate::Delegation::try_sign(
                 &carol_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(alice.clone()))
-                    .issuer(carol.clone())
-                    .audience(dan.clone())
-                    .command("/test/me".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    issuer: carol.clone(),
+                    audience: dan.clone(),
+                    command: "/test/me".into(),
+                }
+                .into(),
             )?;
 
             store.insert(carol_to_dan.clone())?;
@@ -675,36 +691,39 @@ mod tests {
             let bob_to_carol = crate::Delegation::try_sign(
                 &bob_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(bob.clone())
-                    .audience(carol.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: bob.clone(),
+                    audience: carol.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 2.                      carol -a-> dave
             let carol_to_dave = crate::Delegation::try_sign(
                 &carol_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(carol.clone())
-                    .audience(dave.clone())
-                    .command("/".into())
-                    .build()?, // I don't love this is now failable
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: carol.clone(),
+                    audience: dave.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 3.  alice -d-> bob
             let alice_to_bob = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(alice.clone()))
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(bob_to_carol.clone())?;
@@ -756,36 +775,39 @@ mod tests {
             let bob_to_carol = crate::Delegation::try_sign(
                 &bob_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(bob.clone())
-                    .audience(carol.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: bob.clone(),
+                    audience: carol.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 2.                      carol -a-> dave
             let carol_to_dave = crate::Delegation::try_sign(
                 &carol_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(carol.clone())
-                    .audience(dave.clone())
-                    .command("/".into())
-                    .build()?, // I don't love this is now failable
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: carol.clone(),
+                    audience: dave.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 3.  alice -d-> bob
             let alice_to_bob = crate::Delegation::try_sign(
                 &alice_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(alice.clone()))
-                    .issuer(alice.clone())
-                    .audience(bob.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(alice.clone()),
+                    issuer: alice.clone(),
+                    audience: bob.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             store.insert(bob_to_carol.clone())?;

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -665,7 +665,7 @@ mod tests {
                 &dnslink_signer,
                 varsig_header.clone(),
                 crate::delegation::Required {
-                    subject: crate::delegation::Subject::Specific(dnslink.clone()),
+                    subject: crate::delegation::Subject::Known(dnslink.clone()),
                     issuer: dnslink.clone(),
                     audience: account.clone(),
                     command: "/".into(),

--- a/src/invocation/agent.rs
+++ b/src/invocation/agent.rs
@@ -638,36 +638,39 @@ mod tests {
             let account_to_server = crate::Delegation::try_sign(
                 &account_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None)
-                    .issuer(account.clone())
-                    .audience(server.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: account.clone(),
+                    audience: server.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 2.                            server -a-> device
             let server_to_device = crate::Delegation::try_sign(
                 &server_signer,
                 varsig_header.clone(), // FIXME can also put this on a builder
-                crate::delegation::PayloadBuilder::default()
-                    .subject(None) // FIXME needs a sibject when we figure out powerbox
-                    .issuer(server.clone())
-                    .audience(device.clone())
-                    .command("/".into())
-                    .build()?, // I don't love this is now failable
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Any,
+                    issuer: server.clone(),
+                    audience: device.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             // 3.  dnslink -d-> account
             let dnslink_to_account = crate::Delegation::try_sign(
                 &dnslink_signer,
                 varsig_header.clone(),
-                crate::delegation::PayloadBuilder::default()
-                    .subject(Some(dnslink.clone()))
-                    .issuer(dnslink.clone())
-                    .audience(account.clone())
-                    .command("/".into())
-                    .build()?,
+                crate::delegation::Required {
+                    subject: crate::delegation::Subject::Specific(dnslink.clone()),
+                    issuer: dnslink.clone(),
+                    audience: account.clone(),
+                    command: "/".into(),
+                }
+                .into(),
             )?;
 
             del_store.insert(account_to_server.clone())?;

--- a/src/invocation/payload.rs
+++ b/src/invocation/payload.rs
@@ -8,6 +8,7 @@ use crate::{
     delegation::{
         self,
         policy::{selector::SelectorError, Predicate},
+        Subject,
     },
     did::{Did, Verifiable},
     time::{Expired, Timestamp},
@@ -179,7 +180,7 @@ impl<A, DID: Did> Payload<A, DID> {
                     return Err(ValidationError::MisalignedIssAud.into());
                 }
 
-                if let Some(proof_subject) = &proof.subject {
+                if let Subject::Specific(proof_subject) = &proof.subject {
                     if self.subject != *proof_subject {
                         return Err(ValidationError::InvalidSubject.into());
                     }

--- a/src/invocation/payload.rs
+++ b/src/invocation/payload.rs
@@ -180,7 +180,7 @@ impl<A, DID: Did> Payload<A, DID> {
                     return Err(ValidationError::MisalignedIssAud.into());
                 }
 
-                if let Subject::Specific(proof_subject) = &proof.subject {
+                if let Subject::Known(proof_subject) = &proof.subject {
                     if self.subject != *proof_subject {
                         return Err(ValidationError::InvalidSubject.into());
                     }


### PR DESCRIPTION
We can change the naming, but figured let's do one of these to figure out how we want to manage this pattern going forward. Overall I like where it landed, though I did the boiler-plate-y thing and made the interface extremely OO with some methods on `DelegationRequired` that implicitly convert to `DelegationBuilder` without requiring an explicit call to `.to_builder()`.

```rust
DelegationRequired {
    subject: Subject::Known(alice),
    issuer: alice,
    audience: bob,
    command: "/".to_string(),

    signer: alice_signer,
    codec: encoding::Preset::DagCbor,
    varsig_header: header::Preset::EdDsa(header::EdDsaHeader {
        codec: encoding::Preset::DagCbor,
    })
}
.with_via(carol)
.with_policy(vec![])
.with_metadata(BTreeMap::from_iter([("foo".into(), 123.into())]))
.try_finalize()
```

I attempted to automatically build the varsig header from the signer + codec, but that won't work super well once we have more than the simplest of signature types, so I reverted those changes.

This code also uses the more common by-ownership version of builder, which lets you easily chain the calls. I previously has this as a series of `&mut`s, but it was less ergonomic; it can be useful in some cases, but I doubt that we'll need to reuse partially-built delegations as a factory.